### PR TITLE
[feat] Startup the API server without a kubernetes cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ matrix:
         - wget -q https://github.com/kubernetes-sigs/kubebuilder/releases/download/v1.0.8/kubebuilder_1.0.8_linux_amd64.tar.gz -O /tmp/kubebuilder.tar.gz
         - sudo tar -zxvf /tmp/kubebuilder.tar.gz -C /usr/local/
         - sudo mv /usr/local/kubebuilder_* /usr/local/kubebuilder
-        - wget -q https://github.com/swaggo/swag/releases/download/v1.6.3/swag_1.6.3_Linux_x86_64.tar.gz -O /tmp/swag.tar.gz
+        - wget -q https://github.com/swaggo/swag/releases/download/v1.6.5/swag_1.6.5_Linux_x86_64.tar.gz -O /tmp/swag.tar.gz
         - sudo tar -zxvf /tmp/swag.tar.gz -C /usr/local/
         - sudo mv /usr/local/swag /usr/bin/
         - wget -q https://github.com/gotestyourself/gotestsum/releases/download/v0.3.4/gotestsum_0.3.4_linux_amd64.tar.gz -O /tmp/gotestsum.tar.gz

--- a/packages/operator/Gopkg.lock
+++ b/packages/operator/Gopkg.lock
@@ -338,33 +338,6 @@
   version = "v0.19.0"
 
 [[projects]]
-  digest = "1:892aa5ecfd3280a3917757429de2a6ae1efa9b7b9051eac747a09f1bc5cad6f8"
-  name = "github.com/go-playground/locales"
-  packages = [
-    ".",
-    "currency",
-  ]
-  pruneopts = "T"
-  revision = "9f105231d3a5f6877a2bf8321dfa15ea6f844b1b"
-  version = "v0.13.0"
-
-[[projects]]
-  digest = "1:4f627e839d131e88ba872745ad9dab8d0902405f4d0ffba4ea051a6f351949d7"
-  name = "github.com/go-playground/universal-translator"
-  packages = ["."]
-  pruneopts = "T"
-  revision = "f87b1403479a348651dbf5f07f5cc6e5fcf07008"
-  version = "v0.17.0"
-
-[[projects]]
-  digest = "1:c909d08f72c7dc89faf1c7d5b624d7260453c042273ba18ede61027fd10f6655"
-  name = "github.com/go-playground/validator"
-  packages = ["."]
-  pruneopts = "T"
-  revision = "691a5f5f25701d0a22785c982db4f22bfac47931"
-  version = "v10.0.1"
-
-[[projects]]
   digest = "1:92d9d8d25bbab74ef8a3c546c121e24542ac984ccdc4f99678e06042a45e71f8"
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
@@ -880,14 +853,6 @@
   pruneopts = "T"
   revision = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e"
   version = "v1.0.2"
-
-[[projects]]
-  digest = "1:cd82b1cb0ad386ce7be27c3009fb352762d2b710d4d04f90be15bac31dd45618"
-  name = "github.com/leodido/go-urn"
-  packages = ["."]
-  pruneopts = "T"
-  revision = "a0f5013415294bb94553821ace21a1a74c0298cc"
-  version = "v1.2.0"
 
 [[projects]]
   digest = "1:de9cc7a0102d0ccc5fbfba2336a0621cb6815581ceab488a30e4a7dbc3286b53"
@@ -2380,7 +2345,6 @@
     "github.com/emicklei/go-restful",
     "github.com/gin-gonic/gin",
     "github.com/go-logr/logr",
-    "github.com/go-playground/validator",
     "github.com/gogo/protobuf/types",
     "github.com/hashicorp/vault/api",
     "github.com/hashicorp/vault/http",

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -4,10 +4,13 @@ KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=600s
 
 ODAHUFLOW_NAMESPACE=odahu-flow
 ODAHUFLOW_SECRET_CONFIG=odahu-flow-operator-config
+# Name of a sed binary
+SED_BIN=sed
 
 # Hardcoded vault token for local development
 TEST_VAULT_ROOT_TOKEN=test_root_token
 
+-include .env
 .EXPORT_ALL_VARIABLES:
 
 all: help
@@ -68,15 +71,15 @@ manifests:  swag
 	# We cannot add, for example, a custom label during the generation process.
 	# That's why we add them using sed tool after generation.
 
-	sed -i '/^  name:.*$$/a \ \ labels:' ${ODAHUFLOW_OPERATOR_GENERATED_ENTITIES}/operator-rbac-role.yaml
-	sed -i '/^  name:.*$$/a \ \ annotations:' ${ODAHUFLOW_OPERATOR_GENERATED_ENTITIES}/*v1alpha1*.yaml
+	"${SED_BIN}" -i '/^  name:.*$$/a \ \ labels:' ${ODAHUFLOW_OPERATOR_GENERATED_ENTITIES}/operator-rbac-role.yaml
+	"${SED_BIN}" -i '/^  name:.*$$/a \ \ annotations:' ${ODAHUFLOW_OPERATOR_GENERATED_ENTITIES}/*v1alpha1*.yaml
 
-	sed -i '/^  labels:$$/a \ \ \ \ {{- include "odahuflow.helm-labels" (dict "component" "operator" "root" .) | nindent 4 }}' ${ODAHUFLOW_OPERATOR_GENERATED_ENTITIES}/*.yaml
-	sed -i '/^  annotations:$$/a \ \ \ \ "helm.sh/hook": "crd-install"' ${ODAHUFLOW_OPERATOR_GENERATED_ENTITIES}/*v1alpha1*.yaml
+	"${SED_BIN}" -i '/^  labels:$$/a \ \ \ \ {{- include "odahuflow.helm-labels" (dict "component" "operator" "root" .) | nindent 4 }}' ${ODAHUFLOW_OPERATOR_GENERATED_ENTITIES}/*.yaml
+	"${SED_BIN}" -i '/^  annotations:$$/a \ \ \ \ "helm.sh/hook": "crd-install"' ${ODAHUFLOW_OPERATOR_GENERATED_ENTITIES}/*v1alpha1*.yaml
 
-	sed -i 's/manager-role/"{{ .Release.Name }}-operator"/g' ${ODAHUFLOW_OPERATOR_GENERATED_ENTITIES}/operator-rbac-role.yaml
-	sed -i '1i{{- if .Values.rbac }}' ${ODAHUFLOW_OPERATOR_GENERATED_ENTITIES}/operator-rbac-role.yaml
-	sed -i '$$a{{- end }}' ${ODAHUFLOW_OPERATOR_GENERATED_ENTITIES}/operator-rbac-role.yaml
+	"${SED_BIN}" -i 's/manager-role/"{{ .Release.Name }}-operator"/g' ${ODAHUFLOW_OPERATOR_GENERATED_ENTITIES}/operator-rbac-role.yaml
+	"${SED_BIN}" -i '1i{{- if .Values.rbac }}' ${ODAHUFLOW_OPERATOR_GENERATED_ENTITIES}/operator-rbac-role.yaml
+	"${SED_BIN}" -i '$$a{{- end }}' ${ODAHUFLOW_OPERATOR_GENERATED_ENTITIES}/operator-rbac-role.yaml
 
 ## fmt: Run go fmt against code
 fmt:
@@ -94,14 +97,14 @@ run-value:
 swag:
 	swag init -g pkg/webserver/server.go
 	# Remove the line with generated timestamp
-	sed -i '3d' docs/docs.go
-	sed -i 's/connection\.//g' docs/*
-	sed -i 's/routes\.//g' docs/*
-	sed -i 's/deployment\.//g' docs/*
-	sed -i 's/training\.//g' docs/*
-	sed -i 's/packaging\.//g' docs/*
-	sed -i 's/configuration\.//g' docs/*
-	sed -i 's/v1alpha1\.//g' docs/*
+	"${SED_BIN}" -i '3d' docs/docs.go
+	"${SED_BIN}" -i 's/connection\.//g' docs/*
+	"${SED_BIN}" -i 's/routes\.//g' docs/*
+	"${SED_BIN}" -i 's/deployment\.//g' docs/*
+	"${SED_BIN}" -i 's/training\.//g' docs/*
+	"${SED_BIN}" -i 's/packaging\.//g' docs/*
+	"${SED_BIN}" -i 's/configuration\.//g' docs/*
+	"${SED_BIN}" -i 's/v1alpha1\.//g' docs/*
 
 ## apply-crds: Apply all odahuflow crds
 apply-crds:

--- a/packages/operator/README.MD
+++ b/packages/operator/README.MD
@@ -1,0 +1,21 @@
+## Setup services
+
+### API service
+
+Execute the following commands to build and launch the API service:
+
+```bash
+cd packages/operator
+
+dep ensure
+
+make generate-all
+make build-all
+
+# The API service will use the current kube config.
+./api
+# If you specify the local backend then the API service will startup etcd and kube API locally.
+# Download the the kubebuilder asset by link https://github.com/kubernetes-sigs/kubebuilder/releases/tag/v1.0.8
+# Specify the KUBEBUILDER_ASSETS environment variable that must point to the unzip asset dir.
+./api --backend-type local
+```

--- a/packages/operator/docs/docs.go
+++ b/packages/operator/docs/docs.go
@@ -2099,7 +2099,8 @@ var doc = `{
             "properties": {
                 "arguments": {
                     "description": "List of arguments. This parameter depends on the specific packaging integration",
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "artifactName": {
                     "description": "Training output artifact name",
@@ -2430,7 +2431,10 @@ var doc = `{
             "properties": {
                 "annotations": {
                     "description": "Annotations for model pods.",
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "image": {
                     "description": "Model Docker image",
@@ -2641,7 +2645,10 @@ var doc = `{
                 },
                 "hyperParameters": {
                     "description": "Model training hyperParameters in parameter:value format",
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "image": {
                     "description": "Train image",
@@ -2779,7 +2786,10 @@ var doc = `{
             "properties": {
                 "additionalEnvironments": {
                     "description": "Additional environments for a training process",
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "defaultImage": {
                     "description": "Default training Docker image",

--- a/packages/operator/docs/swagger.json
+++ b/packages/operator/docs/swagger.json
@@ -2082,7 +2082,8 @@
             "properties": {
                 "arguments": {
                     "description": "List of arguments. This parameter depends on the specific packaging integration",
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "artifactName": {
                     "description": "Training output artifact name",
@@ -2413,7 +2414,10 @@
             "properties": {
                 "annotations": {
                     "description": "Annotations for model pods.",
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "image": {
                     "description": "Model Docker image",
@@ -2624,7 +2628,10 @@
                 },
                 "hyperParameters": {
                     "description": "Model training hyperParameters in parameter:value format",
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "image": {
                     "description": "Train image",
@@ -2762,7 +2769,10 @@
             "properties": {
                 "additionalEnvironments": {
                     "description": "Additional environments for a training process",
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "defaultImage": {
                     "description": "Default training Docker image",

--- a/packages/operator/docs/swagger.yaml
+++ b/packages/operator/docs/swagger.yaml
@@ -132,6 +132,7 @@ definitions:
   ModelPackagingSpec:
     properties:
       arguments:
+        additionalProperties: true
         description: List of arguments. This parameter depends on the specific packaging
           integration
         type: object
@@ -385,6 +386,8 @@ definitions:
   ModelDeploymentSpec:
     properties:
       annotations:
+        additionalProperties:
+          type: string
         description: Annotations for model pods.
         type: object
       image:
@@ -554,6 +557,8 @@ definitions:
           $ref: '#/definitions/EnvironmentVariable'
         type: array
       hyperParameters:
+        additionalProperties:
+          type: string
         description: Model training hyperParameters in parameter:value format
         type: object
       image:
@@ -656,6 +661,8 @@ definitions:
   ToolchainIntegrationSpec:
     properties:
       additionalEnvironments:
+        additionalProperties:
+          type: string
         description: Additional environments for a training process
         type: object
       defaultImage:

--- a/packages/operator/pkg/config/api/api.go
+++ b/packages/operator/pkg/config/api/api.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api
+
+import (
+	"github.com/spf13/viper"
+	"path/filepath"
+)
+
+const (
+	// Type of the backend. Available values:
+	//    * local
+	//    * config
+	BackendType = "api.backend.type"
+	// Path to a dir with Legion CRDs
+	LocalBackendCRDPath = "api.backend.local.crd_path"
+	// WEB Server port
+	Port = "api.port"
+)
+
+const (
+	LocalBackendType  = "local"
+	ConfigBackendType = "config"
+)
+
+func init() {
+	viper.SetDefault(BackendType, ConfigBackendType)
+	viper.SetDefault(LocalBackendCRDPath, filepath.Join("config", "crds"))
+
+	viper.SetDefault(Port, 5000)
+}

--- a/packages/operator/pkg/webserver/routes/prometheus_test.go
+++ b/packages/operator/pkg/webserver/routes/prometheus_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 )
 
@@ -58,6 +59,8 @@ func (s *PrometheusSuite) TestMonitoring() {
 	s.g.Expect(responseBody).Should(ContainSubstring("gin_request_duration_seconds"))
 	// Golang metrics
 	s.g.Expect(responseBody).Should(ContainSubstring("go_memstats_stack_inuse_bytes"))
-	// System metrics
-	s.g.Expect(responseBody).Should(ContainSubstring("process_open_fds"))
+	// a Linux specific metric
+	if runtime.GOOS == "linux" {
+		s.g.Expect(responseBody).Should(ContainSubstring("process_open_fds"))
+	}
 }


### PR DESCRIPTION
Provided new config options to startup the API server that
will use kubebuilder test assets to emulate the kube API.

Upgraded the swag to the 1.6.5 version.

Allowed to configure the name of sed executable in the Makefile.

Removed the redundant operator dependencies.

Implemented graceful shutdown for API service.

Optionally run the linux specific tests.