### PR TITLE
Feat/123 nodepool final

### DIFF
--- a/helms/odahu-flow-core/templates/operator/deploymentwebhook-rbac.yaml
+++ b/helms/odahu-flow-core/templates/operator/deploymentwebhook-rbac.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: "{{ .Release.Name }}-webhook-admin-role"
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ .Release.Name }}-webhook-admin-role"
+subjects:
+  - kind: ServiceAccount
+    name:  "{{ .Release.Name }}-operator"
+    namespace: "{{ .Release.Namespace }}"
+roleRef:
+  kind: ClusterRole
+  name: "{{ .Release.Name }}-webhook-admin-role"
+  apiGroup: rbac.authorization.k8s.io

--- a/helms/odahu-flow-core/templates/operator/server.yaml
+++ b/helms/odahu-flow-core/templates/operator/server.yaml
@@ -29,6 +29,10 @@ spec:
         imagePullPolicy: Always
         name: operator
         env:
+          - name: OPERATOR_NAMESPACE
+            valueFrom:
+             fieldRef:
+              fieldPath: metadata.namespace
           - name: PACKAGING_MODEL_PACKAGER_IMAGE
             value: "{{ include "odahuflow.image-name" (dict "root" . "service" .Values.config.packaging.modelPackager "tpl" "%sodahu-flow-model-packager:%s") }}"
           - name: TRAINING_MODEL_TRAINER_IMAGE

--- a/packages/operator/Gopkg.lock
+++ b/packages/operator/Gopkg.lock
@@ -365,12 +365,12 @@
   version = "v1.4.1"
 
 [[projects]]
-  digest = "1:74c676217f6583261297ef51c00d945ab470ff5ec5db5a9bf3dcd4cce85ea95f"
-  name = "github.com/gobuffalo/envy"
+  digest = "1:732a5d1779a864055dfcaa46deb1e7bea9b4de4f29eead5b44309893cf5f75b5"
+  name = "github.com/gobuffalo/flect"
   packages = ["."]
   pruneopts = "T"
-  revision = "fa0dfdc10b5366ce365b7d9d1755a03e4e797bc5"
-  version = "v1.6.15"
+  revision = "7a04ff140e0fd2ea77adfd5b8bd2b0c80ab739a9"
+  version = "v0.2.1"
 
 [[projects]]
   digest = "1:c6e109ed32d266dea072dd6d00e3ee26fb960f86ed0ba7f6a07e5d2bfdeab868"
@@ -440,19 +440,19 @@
   revision = "6f77996f0c42f7b84e5a2b252227263f93432e9b"
 
 [[projects]]
-  digest = "1:9502d3f5526c8c5d234ba0575ce046a5b15f08cd9586e4370a2d61d198b68895"
+  digest = "1:cd294c5be5e2f5c7c642c50e4f1c190cdf72fd7a72094351985b97aa0cdeefcb"
   name = "github.com/google/go-containerregistry"
   packages = ["pkg/name"]
   pruneopts = "T"
-  revision = "ec69c4a8a1bff25fcbe096fcb32c9a6543fbdccf"
+  revision = "b02d448a3705facf11018efff34f1d2830be5724"
 
 [[projects]]
-  branch = "master"
-  digest = "1:3ee90c0d94da31b442dde97c99635aaafec68d0b8a3c12ee2075c6bdabeec6bb"
+  digest = "1:a840b166971a2e76fcc4fbafaa181ea109b92d461e7f9b608a49b70be2765bac"
   name = "github.com/google/gofuzz"
   packages = ["."]
   pruneopts = "T"
-  revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
+  revision = "db92cf7ae75e4a7a28abc005addab2b394362888"
+  version = "v1.1.0"
 
 [[projects]]
   digest = "1:582b704bebaa06b48c29b0cec224a6058a09c86883aaddabde889cd1a5f73e1b"
@@ -476,14 +476,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2a7b09c37abc890d89d5c66cc60c9559c3628f09c16cae54a902aa3673d69362"
+  digest = "1:3fd71568acc0a8122ddfda5873fb47ce0f40da6788a6d8872f4cc20ff7e8f502"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
     "diskcache",
   ]
   pruneopts = "T"
-  revision = "3befbb6ad0cc97d4c25d851e9528915809e1a22f"
+  revision = "901d90724c7919163f472a9812253fb26761123d"
 
 [[projects]]
   digest = "1:0ade334594e69404d80d9d323445d2297ff8161637f9b2d347cc6973d2d6f05b"
@@ -776,14 +776,6 @@
   revision = "c2b33e84"
 
 [[projects]]
-  digest = "1:ee5840274624ad20cac08227aeca582fbdaf3727ef9dd37ae935706240679e09"
-  name = "github.com/joho/godotenv"
-  packages = ["."]
-  pruneopts = "T"
-  revision = "23d116af351c84513e1946b527c88823e476be13"
-  version = "v1.3.0"
-
-[[projects]]
   digest = "1:e4f630893d2bbf8c268eba14e7cc92ef8844ee259a45e21ea77cf7656544cb7e"
   name = "github.com/json-iterator/go"
   packages = ["."]
@@ -822,48 +814,15 @@
   revision = "a054578053044161085030449d77f6ceee2cc31a"
 
 [[projects]]
-  digest = "1:0b427e3668f020bb4a40ff6f5fd516d6ff5d70c1f6b55765bbbc4d842a770362"
-  name = "github.com/knative/build"
-  packages = [
-    "pkg/apis/build",
-    "pkg/apis/build/v1alpha1",
-  ]
-  pruneopts = "T"
-  revision = "002a41a30693d0a720ba34476336fc81ba299564"
-  version = "v0.6.0"
-
-[[projects]]
-  branch = "master"
-  digest = "1:20c7bd078e651be068f7dd374e3a3d2299dbe162f3d61f076596e60ceacb12a8"
-  name = "github.com/knative/pkg"
-  packages = [
-    "apis",
-    "apis/duck",
-    "apis/duck/v1alpha1",
-    "apis/duck/v1beta1",
-    "configmap",
-    "kmeta",
-    "kmp",
-    "ptr",
-  ]
-  pruneopts = "T"
-  revision = "d82505e6c5b4ce46562d6c242be0e706791f35bd"
-
-[[projects]]
-  digest = "1:696d4ea394c9d92b4df5a39456a58110fd9b45eaa7ddd898d60bb15f17bf3421"
+  digest = "1:80a77cb9bc208dd5d99f43d5633841726c1c48b8930cd54a2983596b0c88c3a6"
   name = "github.com/knative/serving"
   packages = [
-    "pkg/apis/autoscaling",
-    "pkg/apis/config",
-    "pkg/apis/networking",
-    "pkg/apis/networking/v1alpha1",
     "pkg/apis/serving",
-    "pkg/apis/serving/v1alpha1",
-    "pkg/apis/serving/v1beta1",
+    "pkg/apis/serving/v1",
   ]
   pruneopts = "T"
-  revision = "6afdcf3c200cc8cffcfdeaa223a00df150f4026f"
-  version = "v0.6.1"
+  revision = "b066e90ccd6f091e0faf65a759f3ce789d373457"
+  version = "v0.9.0"
 
 [[projects]]
   digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
@@ -904,14 +863,6 @@
   ]
   pruneopts = "T"
   revision = "1ea4449da9834f4d333f1cc461c374aea217d249"
-
-[[projects]]
-  digest = "1:3804a3a02964db8e6db3e5e7960ac1c1a9b12835642dd4f4ac4e56c749ec73eb"
-  name = "github.com/markbates/inflect"
-  packages = ["."]
-  pruneopts = "T"
-  revision = "24b83195037b3bc61fcda2d28b7b0518bce293b6"
-  version = "v1.0.4"
 
 [[projects]]
   branch = "master"
@@ -1158,19 +1109,19 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0c29d499ffc3b9f33e7136444575527d0c3a9463a89b3cbeda0523b737f910b3"
+  digest = "1:e3c9ed9dca0ac77a50165f6752391fd915b26a020691a731d778304e7b17725b"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
   pruneopts = "T"
-  revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
+  revision = "33fb24c13b99c46c93183c291836c573ac382536"
 
 [[projects]]
-  digest = "1:598241bd36d3a5f6d9102a306bd9bf78f3bc253672460d92ac70566157eae648"
+  digest = "1:d7a1d3a7087a69064f1055538e59873c01dac493e5ff30893b1bcaeb822686c4"
   name = "github.com/peterbourgon/diskv"
   packages = ["."]
   pruneopts = "T"
-  revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
-  version = "v2.0.1"
+  revision = "0be1b92a6df0e4f5cb0a5d15fb7f643d0ad93ce6"
+  version = "v3.0.0"
 
 [[projects]]
   digest = "1:8cf21019a14a486cab3b0fd97aa78cdf58bc7efcaf7dc9d1b4b8cb76fefa17d6"
@@ -1255,18 +1206,6 @@
   pruneopts = "T"
   revision = "01668ae55fe0b79a483095689043cce3e80260db"
   version = "v1.1"
-
-[[projects]]
-  digest = "1:03f9ad9d20d5d7ba2aa68c63f90138f1ab8872ad41a67d77abf6cf329dc644e3"
-  name = "github.com/rogpeppe/go-internal"
-  packages = [
-    "modfile",
-    "module",
-    "semver",
-  ]
-  pruneopts = "T"
-  revision = "1cf9852c553c5b7da2d5a4a091129a7822fed0c9"
-  version = "v1.2.2"
 
 [[projects]]
   digest = "1:6baa565fe16f8657cf93469b2b8a6c61a277827734400d27e44d589547297279"
@@ -1583,6 +1522,7 @@
     "http/httpguts",
     "http/httpproxy",
     "http2",
+    "http2/h2c",
     "http2/hpack",
     "idna",
     "internal/timeseries",
@@ -1942,7 +1882,7 @@
   revision = "162827b552e84a48f0d9d45a8f10ea1623706663"
 
 [[projects]]
-  digest = "1:a8dd0f5c1137ed558bca1fed6617b019aa645783731d15138abc6f184952fef5"
+  digest = "1:a361d526b77e9f68ba9f5d6f2f24e58e00d87f837b1d4cfc977047a37a7522cf"
   name = "k8s.io/api"
   packages = [
     "admission/v1beta1",
@@ -1980,11 +1920,11 @@
     "storage/v1beta1",
   ]
   pruneopts = "T"
-  revision = "05914d821849570fba9eacfb29466f2d8d3cd229"
-  version = "kubernetes-1.13.1"
+  revision = "5cb15d34447165a97c76ed5a60e4e99c8a01ecfe"
+  version = "kubernetes-1.13.4"
 
 [[projects]]
-  digest = "1:d6b5f1f23ca1b4a68aacbe3167fdd56babaf4b0a72b5d0c166595cee4b71532d"
+  digest = "1:29ba6118af0c631600c5f773d4c99b09ffb6306ceefcffa91bb524483da7a67b"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
@@ -1994,11 +1934,11 @@
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
   ]
   pruneopts = "T"
-  revision = "0fe22c71c47604641d9aa352c785b7912c200562"
-  version = "kubernetes-1.13.1"
+  revision = "d002e88f6236312f0289d9d1deab106751718ff0"
+  version = "kubernetes-1.13.4"
 
 [[projects]]
-  digest = "1:6326c0acd4934569b53d305d4a79a30f7074b3d4fdb3537af06203b68297a22b"
+  digest = "1:82717527f44f2cb9a2a784a427a7ab9bd7f883848bdfabcf70bef8e300b69fa5"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -2050,11 +1990,11 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "T"
-  revision = "2b1284ed4c93a43499e781493253e2ac5959c4fd"
-  version = "kubernetes-1.13.1"
+  revision = "86fb29eff6288413d76bd8506874fddd9fccdff0"
+  version = "kubernetes-1.13.4"
 
 [[projects]]
-  digest = "1:0b3ba6818a03b0f0f181ab6b88d9be03789d02ede8929d876f45210471811fdb"
+  digest = "1:00cdd77acb3883ae851a1cd8c2b3ede01cd974dd9283ff4022f98dbb6e1455dd"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -2201,8 +2141,8 @@
     "util/workqueue",
   ]
   pruneopts = "T"
-  revision = "8d9ed539ba3134352c586810e749e58df4e94e4f"
-  version = "kubernetes-1.13.1"
+  revision = "b40b2a5939e43f7ffe0028ad67586b7ce50bb675"
+  version = "kubernetes-1.13.4"
 
 [[projects]]
   branch = "master"
@@ -2258,8 +2198,8 @@
   revision = "5e45bb682580c9be5ffa4d27d367f0eeba125c7b"
 
 [[projects]]
-  branch = "master"
-  digest = "1:eff1820d1e919aabae9c6c6dba7861c62aba8841bcd4921714b8723c85d46356"
+  branch = "release-0.9"
+  digest = "1:19beb74b5d34a69dc256f965c3ef2519fdb2ae74590174b1231a1f0da7e26fd4"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -2268,13 +2208,32 @@
     "apis/duck/v1beta1",
     "apis/v1alpha1",
     "configmap",
+    "kmeta",
     "kmp",
+    "network",
+    "ptr",
   ]
   pruneopts = "T"
-  revision = "4b3befdaaae1d32f50fbdc42ca9de6fd1cfc0967"
+  revision = "74659889c421b26b9a416fd203f5a8d3e602bfb2"
 
 [[projects]]
-  digest = "1:5aa50779f75cc439edd3455a6dee7cf179b52f8dde764a47cc929693485d1afb"
+  digest = "1:80a77cb9bc208dd5d99f43d5633841726c1c48b8930cd54a2983596b0c88c3a6"
+  name = "knative.dev/serving"
+  packages = [
+    "pkg/apis/autoscaling",
+    "pkg/apis/config",
+    "pkg/apis/networking",
+    "pkg/apis/serving",
+    "pkg/gc",
+    "pkg/network",
+    "pkg/reconciler/route/config",
+  ]
+  pruneopts = "T"
+  revision = "b066e90ccd6f091e0faf65a759f3ce789d373457"
+  version = "v0.9.0"
+
+[[projects]]
+  digest = "1:fbd9138a454764d4037f8edeb7bdea3f4ef4ad24b672a52cceff2a9609aacf91"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/cache",
@@ -2290,6 +2249,7 @@
     "pkg/handler",
     "pkg/internal/controller",
     "pkg/internal/controller/metrics",
+    "pkg/internal/objectutil",
     "pkg/internal/recorder",
     "pkg/leaderelection",
     "pkg/manager",
@@ -2304,22 +2264,17 @@
     "pkg/runtime/signals",
     "pkg/source",
     "pkg/source/internal",
-    "pkg/webhook",
     "pkg/webhook/admission",
     "pkg/webhook/admission/types",
-    "pkg/webhook/internal/cert",
-    "pkg/webhook/internal/cert/generator",
-    "pkg/webhook/internal/cert/writer",
-    "pkg/webhook/internal/cert/writer/atomic",
     "pkg/webhook/internal/metrics",
     "pkg/webhook/types",
   ]
   pruneopts = "T"
-  revision = "12d98582e72927b6cd0123e2b4e819f9341ce62c"
-  version = "v0.1.10"
+  revision = "f1eaba5087d69cebb154c6a48193e6667f5b512c"
+  version = "v0.1.12"
 
 [[projects]]
-  digest = "1:adfc3ea3c2a575c2f6315f17dfcddd6fb49247a1a1b055febc2a44b35e59ca10"
+  digest = "1:46aa448122b04f923ce877ab57d4649dfe5437a028ae8700876d7c5070909b08"
   name = "sigs.k8s.io/controller-tools"
   packages = [
     "cmd/controller-gen",
@@ -2331,11 +2286,10 @@
     "pkg/rbac",
     "pkg/util",
     "pkg/webhook",
-    "pkg/webhook/internal",
   ]
   pruneopts = "T"
-  revision = "fbf141159251d035089e7acdd5a343f8cec91b94"
-  version = "v0.1.9"
+  revision = "eb20812245b721a69012140fcf07e887b4f2e5d8"
+  version = "v0.1.12"
 
 [[projects]]
   digest = "1:290b4da306982122bcdff12dbababbb95c6e4a94a2995db88baf235ef2f6e93e"
@@ -2381,8 +2335,7 @@
     "github.com/hashicorp/vault/http",
     "github.com/hashicorp/vault/vault",
     "github.com/knative/serving/pkg/apis/serving",
-    "github.com/knative/serving/pkg/apis/serving/v1alpha1",
-    "github.com/knative/serving/pkg/apis/serving/v1beta1",
+    "github.com/knative/serving/pkg/apis/serving/v1",
     "github.com/ncw/rclone/backend/azureblob",
     "github.com/ncw/rclone/backend/googlecloudstorage",
     "github.com/ncw/rclone/backend/local",

--- a/packages/operator/Gopkg.toml
+++ b/packages/operator/Gopkg.toml
@@ -20,8 +20,20 @@ required = [
   go-tests = true
 
 [[override]]
+  name = "github.com/knative/serving"
+  version="v0.9.0"
+
+[[override]]
+  name =  "knative.dev/serving"
+  version="v0.9.0"
+
+[[override]]
+  name =  "knative.dev/pkg"
+  branch="release-0.9"
+
+[[override]]
   name = "k8s.io/apimachinery"
-  version="kubernetes-1.13.1"
+  version="kubernetes-1.13.4"
 
 [[override]]
   name = "github.com/spf13/viper"
@@ -33,11 +45,11 @@ required = [
 
 [[override]]
   name = "k8s.io/client-go"
-  version="kubernetes-1.13.1"
+  version="kubernetes-1.13.4"
 
 [[override]]
   name = "k8s.io/api"
-  version = "kubernetes-1.13.1"
+  version = "kubernetes-1.13.4"
 
 [[override]]
   name = "github.com/Azure/azure-pipeline-go"

--- a/packages/operator/pkg/config/deployment.go
+++ b/packages/operator/pkg/config/deployment.go
@@ -16,7 +16,10 @@
 
 package config
 
-import odahuflowv1alpha1 "github.com/odahu/odahu-flow/packages/operator/pkg/apis/odahuflow/v1alpha1"
+import (
+	odahuflowv1alpha1 "github.com/odahu/odahu-flow/packages/operator/pkg/apis/odahuflow/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+)
 
 var (
 	defaultDeploymentMemoryLimit    = "256Mi"
@@ -52,15 +55,6 @@ type ModelDeploymentSecurityConfig struct {
 	RoleName string `json:"roleName"`
 }
 
-
-type Toleration struct {
-	Effect string `json:"Effect"`
-	Key string `json:"Key"`
-	Operator string `json:"Operator"`
-	Value string `json:"Value"`
-	TolerationSeconds *int64 `json:"TolerationSeconds"`
-}
-
 type ModelDeploymentConfig struct {
 	// Kubernetes namespace, where model deployments will be deployed
 	Namespace string `json:"namespace"`
@@ -73,7 +67,7 @@ type ModelDeploymentConfig struct {
 	// Kubernetes node selector for model deployments
 	NodeSelector map[string]string `json:"nodeSelector"`
 	// Kubernetes tolerations for model deployments
-	Toleration                *Toleration                   `json:"toleration,omitempty"`
+	Toleration                *v1.Toleration                `json:"toleration,omitempty"`
 	Istio                     ModelDeploymentIstioConfig    `json:"istio"`
 	// Default resources for deployment pods
 	DefaultResources odahuflowv1alpha1.ResourceRequirements `json:"defaultResources"`

--- a/packages/operator/pkg/config/deployment.go
+++ b/packages/operator/pkg/config/deployment.go
@@ -52,6 +52,15 @@ type ModelDeploymentSecurityConfig struct {
 	RoleName string `json:"roleName"`
 }
 
+
+type Toleration struct {
+	Effect string `json:"Effect"`
+	Key string `json:"Key"`
+	Operator string `json:"Operator"`
+	Value string `json:"Value"`
+	TolerationSeconds *int64 `json:"TolerationSeconds"`
+}
+
 type ModelDeploymentConfig struct {
 	// Kubernetes namespace, where model deployments will be deployed
 	Namespace string `json:"namespace"`
@@ -64,8 +73,8 @@ type ModelDeploymentConfig struct {
 	// Kubernetes node selector for model deployments
 	NodeSelector map[string]string `json:"nodeSelector"`
 	// Kubernetes tolerations for model deployments
-	Toleration map[string]string          `json:"toleration"`
-	Istio      ModelDeploymentIstioConfig `json:"istio"`
+	Toleration                *Toleration                   `json:"toleration,omitempty"`
+	Istio                     ModelDeploymentIstioConfig    `json:"istio"`
 	// Default resources for deployment pods
 	DefaultResources odahuflowv1alpha1.ResourceRequirements `json:"defaultResources"`
 }

--- a/packages/operator/pkg/config/operator.go
+++ b/packages/operator/pkg/config/operator.go
@@ -16,14 +16,17 @@
 
 package config
 
+import "os"
+
 type OperatorConfig struct {
-	Auth AuthConfig `json:"auth"`
+	Auth AuthConfig       `json:"auth"`
 	// Operator HTTP monitoring port
-	MonitoringPort int `json:"monitoringPort"`
+	MonitoringPort int    `json:"monitoringPort"`
+	Namespace      string `json:"-"`
 }
 
 func NewDefaultOperatorConfig() OperatorConfig {
 	return OperatorConfig{
 		MonitoringPort: 7777,
-	}
+		Namespace:      os.Getenv("OPERATOR_NAMESPACE")}
 }

--- a/packages/operator/pkg/controller/add_deployments.go
+++ b/packages/operator/pkg/controller/add_deployments.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"github.com/odahu/odahu-flow/packages/operator/pkg/config"
 	"github.com/odahu/odahu-flow/packages/operator/pkg/controller/modeldeployment"
+	"github.com/odahu/odahu-flow/packages/operator/pkg/controller/deploymenthook"
 	"github.com/odahu/odahu-flow/packages/operator/pkg/controller/modelroute"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -27,6 +28,7 @@ func init() {
 	// AddToManagerDeploymentFuncs is a list of functions to create controllers and add them to a manager.
 	AddToManagerDeploymentFuncs = append(AddToManagerDeploymentFuncs, modeldeployment.Add)
 	AddToManagerDeploymentFuncs = append(AddToManagerDeploymentFuncs, modelroute.Add)
+	AddToManagerDeploymentFuncs = append(AddToManagerDeploymentFuncs, deploymenthook.Add)
 }
 
 // AddToManagerDeploymentFuncs is a list of functions to add all Controllers to the Manager

--- a/packages/operator/pkg/controller/controller.go
+++ b/packages/operator/pkg/controller/controller.go
@@ -18,7 +18,7 @@ package controller
 
 import (
 	istioschema "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned/scheme"
-	knservingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	v1 "github.com/knative/serving/pkg/apis/serving/v1"
 	"github.com/odahu/odahu-flow/packages/operator/pkg/config"
 	tektonschema "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -68,7 +68,7 @@ func AddToManager(m manager.Manager, odahuConfig *config.Config) error {
 		istioschema.AddToScheme(m.GetScheme())
 
 		log.Info("Setting up Knative scheme")
-		if err := knservingv1alpha1.AddToScheme(m.GetScheme()); err != nil {
+		if err := v1.AddToScheme(m.GetScheme()); err != nil {
 			log.Error(err, "unable add Knative APIs to scheme")
 
 			return err

--- a/packages/operator/pkg/controller/deploymenthook/deploymenthook.go
+++ b/packages/operator/pkg/controller/deploymenthook/deploymenthook.go
@@ -1,0 +1,131 @@
+package deploymenthook
+
+import (
+	"context"
+	"github.com/odahu/odahu-flow/packages/operator/pkg/config"
+	"github.com/odahu/odahu-flow/packages/operator/pkg/odahuflow"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+const (
+	webhookName        = "modeldeployment-webhook"
+	webhookServerName  = "modeldeployment-webhook-server"
+	webhookServiceName = "modeldeployment-webhook-service"
+	webhookSecretName  = "modeldeployment-webhook-secret"
+	webhookconfigName  = "modeldeployment-webhook-config"
+)
+
+// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=ignore,groups="",resources=pods,verbs=create;update,versions=v1,name=modeldeployment-webhook
+
+func Add(
+	mgr manager.Manager,
+	deploymentConfig config.ModelDeploymentConfig,
+	_ config.OperatorConfig,
+	_ string,
+) error {
+	log := logf.Log.WithName(webhookName).WithValues(odahuflow.ModelDeploymentIDLogPrefix)
+	log.Info("Creating model deployment webhook for knative pods")
+
+	wh, err := builder.NewWebhookBuilder().
+		Name(webhookName).
+		Mutating().
+		Operations(admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update).
+		WithManager(mgr).
+		ForType(&corev1.Pod{}).
+		NamespaceSelector(&metav1.LabelSelector{MatchLabels: map[string]string{"namespace": deploymentConfig.Namespace}}).
+		Handlers(&podMutator{deploymentConfig: deploymentConfig}).
+		Build()
+	if err != nil {
+		return err
+	}
+
+	log.Info("Setting up webhook server")
+	as, err := webhook.NewServer(webhookServerName, mgr, webhook.ServerOptions{
+		Port: 6443,
+		BootstrapOptions: &webhook.BootstrapOptions{
+			MutatingWebhookConfigName: webhookconfigName,
+			Secret: &apitypes.NamespacedName{
+				Namespace: deploymentConfig.Namespace,
+				Name:      webhookSecretName,
+			},
+			Service: &webhook.Service{
+				Namespace: deploymentConfig.Namespace,
+				Name:      webhookServiceName,
+				Selectors: deploymentConfig.NodeSelector,
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Info("Registering webhooks to the webhook server")
+	err = as.Register(wh)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type podMutator struct {
+	client           client.Client
+	decoder          types.Decoder
+	deploymentConfig config.ModelDeploymentConfig
+}
+
+// Implement admission.Handler so the controller can handle admission request.
+var _ admission.Handler = &podMutator{}
+
+// podMutator adds an annotation to every incoming pods.
+func (pm *podMutator) Handle(_ context.Context, req types.Request) types.Response {
+	pod := &corev1.Pod{}
+
+	err := pm.decoder.Decode(req, pod)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+
+	podCopy := pod.DeepCopy()
+	err = pm.addNodeSelectors(podCopy)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponse(pod, podCopy)
+}
+
+//Adds node selectors from deployment config to knative pods
+func (pm *podMutator) addNodeSelectors(pod *corev1.Pod) error {
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+	pod.Spec.NodeSelector = pm.deploymentConfig.NodeSelector
+	return nil
+}
+
+//Client and Decoder are auto injected
+var _ inject.Client = &podMutator{}
+
+func (pm *podMutator) InjectClient(c client.Client) error {
+	pm.client = c
+	return nil
+}
+
+var _ inject.Decoder = &podMutator{}
+
+func (pm *podMutator) InjectDecoder(d types.Decoder) error {
+	pm.decoder = d
+	return nil
+}

--- a/packages/operator/pkg/controller/deploymenthook/deploymenthook.go
+++ b/packages/operator/pkg/controller/deploymenthook/deploymenthook.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"net/http"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -96,7 +95,6 @@ func Add(
 }
 
 type podMutator struct {
-	client           client.Client
 	decoder          types.Decoder
 	deploymentConfig config.ModelDeploymentConfig
 }
@@ -131,7 +129,8 @@ func (pm *podMutator) addNodeSelectors(pod *corev1.Pod) error {
 
 	toleration := pm.deploymentConfig.Toleration
 	if toleration != nil {
-		v1Toleration := corev1.Toleration{Key: toleration.Key,
+		v1Toleration := corev1.Toleration{
+			Key:               toleration.Key,
 			Operator:          corev1.TolerationOperator(toleration.Operator),
 			Value:             toleration.Value,
 			Effect:            corev1.TaintEffect(toleration.Effect),

--- a/packages/operator/pkg/controller/deploymenthook/deploymenthook.go
+++ b/packages/operator/pkg/controller/deploymenthook/deploymenthook.go
@@ -129,13 +129,7 @@ func (pm *podMutator) addNodeSelectors(pod *corev1.Pod) error {
 
 	toleration := pm.deploymentConfig.Toleration
 	if toleration != nil {
-		v1Toleration := corev1.Toleration{
-			Key:               toleration.Key,
-			Operator:          corev1.TolerationOperator(toleration.Operator),
-			Value:             toleration.Value,
-			Effect:            corev1.TaintEffect(toleration.Effect),
-			TolerationSeconds: toleration.TolerationSeconds}
-		pod.Spec.Tolerations = append(pod.Spec.Tolerations, v1Toleration)
+		pod.Spec.Tolerations = append(pod.Spec.Tolerations, *toleration)
 		log.Info("Assigning toleration to a pod", "toleration", toleration, "pod name", pod.Name)
 	} else {
 		log.Info("Got empty toleration from deployment config, skipping", "pod name", pod.Name)

--- a/packages/operator/pkg/controller/deploymenthook/deploymenthook.go
+++ b/packages/operator/pkg/controller/deploymenthook/deploymenthook.go
@@ -21,11 +21,13 @@ import (
 )
 
 const (
-	webhookName        = "modeldeployment-webhook"
-	webhookServerName  = "modeldeployment-webhook-server"
-	webhookServiceName = "modeldeployment-webhook-service"
-	webhookSecretName  = "modeldeployment-webhook-secret"
-	webhookconfigName  = "modeldeployment-webhook-config"
+	webhookName            = "modeldeployment-webhook"
+	webhookServerName      = "modeldeployment-webhook-server"
+	webhookServiceName     = "modeldeployment-webhook-service"
+	webhookSecretName      = "modeldeployment-webhook-secret"
+	webhookconfigName      = "modeldeployment-webhook-config"
+	namespaceSelectorKey   = "modeldeployment-webhook"
+	namespaceSelectorValue = "enabled"
 )
 
 func Add(
@@ -38,12 +40,11 @@ func Add(
 	log.Info("Creating model deployment webhook for knative pods")
 
 	wh, err := builder.NewWebhookBuilder().
-		Name(webhookName).
 		Mutating().
 		Operations(admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update).
 		WithManager(mgr).
 		ForType(&corev1.Pod{}).
-		NamespaceSelector(&metav1.LabelSelector{MatchLabels: map[string]string{"namespace": deploymentConfig.Namespace}}).
+		NamespaceSelector(&metav1.LabelSelector{MatchLabels: map[string]string{namespaceSelectorKey: namespaceSelectorValue}}).
 		Handlers(&podMutator{deploymentConfig: deploymentConfig}).
 		Build()
 	if err != nil {

--- a/packages/operator/pkg/controller/deploymenthook/deploymenthook_test.go
+++ b/packages/operator/pkg/controller/deploymenthook/deploymenthook_test.go
@@ -1,0 +1,54 @@
+//
+//    Copyright 2019 EPAM Systems
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+package deploymenthook
+
+import (
+	"github.com/odahu/odahu-flow/packages/operator/pkg/config"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestPodMutator(t *testing.T) {
+	intVal := 42
+	int64Val := int64(intVal)
+	nodeSelector := map[string]string{"label": "labelValue"}
+	toleration := &corev1.Toleration{
+		Key:               "key",
+		Operator:          corev1.TolerationOpExists,
+		Value:             "value",
+		Effect:            corev1.TaintEffectNoSchedule,
+		TolerationSeconds: &int64Val}
+	defaultToleration := corev1.Toleration{
+		Key:               "defaultKey",
+		Operator:          corev1.TolerationOpEqual,
+		Value:             "defaultValue",
+		Effect:            corev1.TaintEffectPreferNoSchedule,
+		TolerationSeconds: &int64Val}
+
+	pm := podMutator{deploymentConfig: config.ModelDeploymentConfig{NodeSelector: nodeSelector, Toleration: toleration}}
+	pod := &corev1.Pod{}
+	pod.Spec.Tolerations = append(pod.Spec.Tolerations, defaultToleration)
+	_ = pm.addNodeSelectors(pod)
+
+	expectedPod := &corev1.Pod{}
+	expectedPod.Spec.Tolerations = append(expectedPod.Spec.Tolerations, defaultToleration, *toleration)
+	expectedPod.Spec.NodeSelector = nodeSelector
+
+	g := NewGomegaWithT(t)
+	g.Expect(pod).Should(BeEquivalentTo(expectedPod))
+}

--- a/packages/operator/pkg/controller/modeldeployment/modeldeployment_controller.go
+++ b/packages/operator/pkg/controller/modeldeployment/modeldeployment_controller.go
@@ -19,6 +19,7 @@ package modeldeployment
 import (
 	"context"
 	"fmt"
+	v1 "github.com/knative/serving/pkg/apis/serving/v1"
 	"github.com/odahu/odahu-flow/packages/operator/pkg/config"
 	"strconv"
 	"time"
@@ -26,8 +27,6 @@ import (
 	authv1alpha1 "github.com/aspenmesh/istio-client-go/pkg/apis/authentication/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/knative/serving/pkg/apis/serving"
-	knservingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
-	"github.com/knative/serving/pkg/apis/serving/v1beta1"
 	odahuflowv1alpha1 "github.com/odahu/odahu-flow/packages/operator/pkg/apis/odahuflow/v1alpha1"
 	"github.com/odahu/odahu-flow/packages/operator/pkg/odahuflow"
 	conn_repository "github.com/odahu/odahu-flow/packages/operator/pkg/repository/connection"
@@ -138,7 +137,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	err = c.Watch(&source.Kind{Type: &knservingv1alpha1.Configuration{}}, &handler.EnqueueRequestForOwner{
+	err = c.Watch(&source.Kind{Type: &v1.Configuration{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &odahuflowv1alpha1.ModelDeployment{},
 	})
@@ -159,7 +158,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	err = c.Watch(&source.Kind{Type: &knservingv1alpha1.Revision{}}, &EnqueueRequestForImplicitOwner{})
+	err = c.Watch(&source.Kind{Type: &v1.Revision{}}, &EnqueueRequestForImplicitOwner{})
 	if err != nil {
 		return err
 	}
@@ -293,13 +292,13 @@ func (r *ReconcileModelDeployment) ReconcileKnativeConfiguration(
 		serviceAccountName = odahuflow.GenerateDeploymentConnectionSecretName(modelDeploymentCR.Name)
 	}
 
-	knativeConfiguration := &knservingv1alpha1.Configuration{
+	knativeConfiguration := &v1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      knativeConfigurationName(modelDeploymentCR),
 			Namespace: modelDeploymentCR.Namespace,
 		},
-		Spec: knservingv1alpha1.ConfigurationSpec{
-			Template: &knservingv1alpha1.RevisionTemplateSpec{
+		Spec: v1.ConfigurationSpec{
+			Template: v1.RevisionTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						modelNameAnnotationKey: modelDeploymentCR.Name,
@@ -312,16 +311,14 @@ func (r *ReconcileModelDeployment) ReconcileKnativeConfiguration(
 						knativeAutoscalingTargetKey: knativeAutoscalingTargetDefaultValue,
 					},
 				},
-				Spec: knservingv1alpha1.RevisionSpec{
-					RevisionSpec: v1beta1.RevisionSpec{
-						TimeoutSeconds: &defaultTerminationPeriod,
-						PodSpec: v1beta1.PodSpec{
-							ServiceAccountName: serviceAccountName,
-							Containers: []corev1.Container{
-								*container,
-							},
+				Spec: v1.RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						ServiceAccountName: serviceAccountName,
+						Containers: []corev1.Container{
+							*container,
 						},
 					},
+					TimeoutSeconds: &defaultTerminationPeriod,
 				},
 			},
 		},
@@ -336,7 +333,7 @@ func (r *ReconcileModelDeployment) ReconcileKnativeConfiguration(
 		return err
 	}
 
-	found := &knservingv1alpha1.Configuration{}
+	found := &v1.Configuration{}
 	err = r.Get(context.TODO(), types.NamespacedName{
 		Name: knativeConfiguration.Name, Namespace: knativeConfiguration.Namespace,
 	}, found)
@@ -515,7 +512,7 @@ func (r *ReconcileModelDeployment) getLatestReadyRevision(
 	log logr.Logger,
 	modelDeploymentCR *odahuflowv1alpha1.ModelDeployment,
 ) (string, bool, error) {
-	knativeConfiguration := &knservingv1alpha1.Configuration{}
+	knativeConfiguration := &v1.Configuration{}
 	if err := r.Get(context.TODO(), types.NamespacedName{
 		Name: knativeConfigurationName(modelDeploymentCR), Namespace: modelDeploymentCR.Namespace,
 	}, knativeConfiguration); errors.IsNotFound(err) {
@@ -709,7 +706,7 @@ func (r *ReconcileModelDeployment) cleanupOldRevisions(
 		return nil
 	}
 
-	lastKnativeRevision := &knservingv1alpha1.Revision{}
+	lastKnativeRevision := &v1.Revision{}
 	if err := r.Get(context.TODO(), types.NamespacedName{
 		Name: lastRevisionName, Namespace: modelDeploymentCR.Namespace,
 	}, lastKnativeRevision); err != nil {
@@ -731,7 +728,7 @@ func (r *ReconcileModelDeployment) cleanupOldRevisions(
 		return err
 	}
 
-	knativeRevisions := &knservingv1alpha1.RevisionList{}
+	knativeRevisions := &v1.RevisionList{}
 
 	labelSelectorReq, err := labels.NewRequirement(
 		modelNameAnnotationKey,

--- a/packages/operator/pkg/controller/modeldeployment/modeldeployment_controller_suite_test.go
+++ b/packages/operator/pkg/controller/modeldeployment/modeldeployment_controller_suite_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	istioschema "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned/scheme"
-	knservingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	v1 "github.com/knative/serving/pkg/apis/serving/v1"
 )
 
 var cfg *rest.Config
@@ -52,7 +52,7 @@ func TestMain(m *testing.M) {
 
 	istioschema.AddToScheme(scheme.Scheme)
 
-	if err := knservingv1alpha1.AddToScheme(scheme.Scheme); err != nil {
+	if err := v1.AddToScheme(scheme.Scheme); err != nil {
 		panic(err)
 	}
 

--- a/packages/operator/pkg/controller/modeldeployment/modeldeployment_controller_test.go
+++ b/packages/operator/pkg/controller/modeldeployment/modeldeployment_controller_test.go
@@ -18,7 +18,7 @@ package modeldeployment
 
 import (
 	"context"
-	knservingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	v1 "github.com/knative/serving/pkg/apis/serving/v1"
 	odahuflowv1alpha1 "github.com/odahu/odahu-flow/packages/operator/pkg/apis/odahuflow/v1alpha1"
 	"github.com/odahu/odahu-flow/packages/operator/pkg/config"
 	"github.com/odahu/odahu-flow/packages/operator/pkg/repository/util/kubernetes"
@@ -107,7 +107,7 @@ func TestReconcile(t *testing.T) {
 	g.Eventually(requests, timeout).Should(Receive(Equal(expectedRequest)))
 	g.Eventually(requests, timeout).Should(Receive(Equal(expectedRequest)))
 
-	configuration := &knservingv1alpha1.Configuration{}
+	configuration := &v1.Configuration{}
 	configurationKey := types.NamespacedName{Name: knativeConfigurationName(md), Namespace: mdNamespace}
 	g.Expect(c.Get(context.TODO(), configurationKey, configuration)).ToNot(HaveOccurred())
 

--- a/packages/operator/pkg/odahuflow/k8s.go
+++ b/packages/operator/pkg/odahuflow/k8s.go
@@ -21,9 +21,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	v1 "github.com/knative/serving/pkg/apis/serving/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	knservingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 )
 
 const (
@@ -75,7 +74,7 @@ func StoreHash(obj metav1.Object) error {
 }
 
 // Compute hash and store it in the annotations
-func StoreHashKnative(obj *knservingv1alpha1.Configuration) error {
+func StoreHashKnative(obj *v1.Configuration) error {
 	h := sha512.New()
 	jsonData, err := json.Marshal(obj)
 	if err != nil {


### PR DESCRIPTION
Added webhook for knative model deployment. It takes nodeSelectors and tolreation from the config and adds to pods created in a specific namespace. Migrated to 0.9 knative version to remove alpha and beta apis as v1 is stable atm. 