### PR TITLE
fix/229-fail-on-unexisted-path

### DIFF
--- a/packages/operator/pkg/rclone/type.go
+++ b/packages/operator/pkg/rclone/type.go
@@ -151,7 +151,7 @@ func (os *ObjectStorage) Download(localPath, remotePath string) error {
 		log.Info("Download directory from the remote bucket",
 			"local_dir", localDir, "remote_dir", remotePath,
 		)
-		result := sync.CopyDir(localFs, remoteFs, copyEmptySrcDirs)
+		result := sync.CopyDir(context.Background(), localFs, remoteFs, copyEmptySrcDirs)
                 _, ok := result.(error)
 		if ok == true {
 			return result

--- a/packages/operator/pkg/rclone/type.go
+++ b/packages/operator/pkg/rclone/type.go
@@ -151,7 +151,11 @@ func (os *ObjectStorage) Download(localPath, remotePath string) error {
 		log.Info("Download directory from the remote bucket",
 			"local_dir", localDir, "remote_dir", remotePath,
 		)
-		return sync.CopyDir(context.Background(), localFs, remoteFs, copyEmptySrcDirs)
+		result := sync.CopyDir(localFs, remoteFs, copyEmptySrcDirs)
+                _, ok := result.(error)
+		if ok == true {
+			return result
+		}
 	}
 
 	if len(localFileName) == 0 {


### PR DESCRIPTION
Return error when rclone fails on copyDir