### PR TITLE
[fix] `additionalPrinterColumns` output for ModelTrainings

### DIFF
--- a/helms/odahu-flow-core/templates/operator/generated/odahuflow_v1alpha1_modeltraining.yaml
+++ b/helms/odahu-flow-core/templates/operator/generated/odahuflow_v1alpha1_modeltraining.yaml
@@ -17,13 +17,13 @@ spec:
   - JSONPath: .spec.vcsName
     name: VCS name
     type: string
-  - JSONPath: .status.modelName
+  - JSONPath: .spec.model.name
     name: Model name
     type: string
-  - JSONPath: .status.modelVersion
+  - JSONPath: .spec.model.version
     name: Model version
     type: string
-  - JSONPath: .status.modelImage
+  - JSONPath: .spec.image
     name: Model image
     type: string
   group: odahuflow.odahu.org


### PR DESCRIPTION
Fix for empty `MODEL NAME`, `MODEL VERSION`, `MODEL IMAGE` columns in output of `kubectl get modeltrainings`.