### PR TITLE
Test report python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,5 +114,3 @@ matrix:
         - make lint
 after_success:
   - codecov
-after_failure:
-  - codecov

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ install-python-tests:
 
 ## python-unittests: Run pythoon unit tests
 python-unittests:
-	DEBUG=true VERBOSE=true pytest -s --cov --cov-branch \
+	DEBUG=true VERBOSE=true pytest -s --cov --cov-report term-missing\
 	          packages/cli packages/sdk
 
 ## setup-e2e-robot: Prepare a test data for the e2e robot tests

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,5 +1,5 @@
 coverage:
-  range: "50...100"
+  range: "80...100"
 
 parsers:
   gcov:


### PR DESCRIPTION
- fixed that code coverage updated with failed build (as not all code coverage counted).
- added missed lines in code coverage report for python
- raised the bottom line of range for code coverage as it shows the line coverage