### PR TITLE
Fix #257 - Validate API host URL on login in CLI

### DIFF
--- a/packages/cli/odahuflow/cli/__main__.py
+++ b/packages/cli/odahuflow/cli/__main__.py
@@ -17,6 +17,6 @@
 CLI main entrypoint
 """
 
-from .main import base
+from .main import main
 
-base()
+main()

--- a/packages/cli/odahuflow/cli/main.py
+++ b/packages/cli/odahuflow/cli/main.py
@@ -86,4 +86,4 @@ def main():
 
 
 if __name__ == '__main__':
-    base()
+    main()

--- a/packages/cli/odahuflow/cli/parsers/security.py
+++ b/packages/cli/odahuflow/cli/parsers/security.py
@@ -96,16 +96,19 @@ def login(api_host: str, token: str, client_id: str, client_secret: str, issuer:
         fetch_openid_conf(config.ISSUER_URL)
 
     # login
+    api_client = api.RemoteAPIClient(api_host, token, client_id, client_secret,
+                                     non_interactive=not is_interactive_login)
     try:
-        api_client = api.RemoteAPIClient(api_host, token, client_id, client_secret,
-                                         non_interactive=not is_interactive_login)
-
         api_client.info()
-
-        print('Success! Credentials have been saved.')
     except api.IncorrectAuthorizationToken as wrong_token:
         LOG.error('Wrong authorization token\n%s', wrong_token)
-        sys.exit(1)
+        raise
+    except api.APIConnectionException as connection_exc:
+        LOG.error(f'Failed to connect to API host!'
+                  f'Error: {connection_exc}')
+        raise
+
+    print('Success! Credentials have been saved.')
 
 
 @click.command()

--- a/packages/cli/odahuflow/cli/parsers/security.py
+++ b/packages/cli/odahuflow/cli/parsers/security.py
@@ -17,7 +17,6 @@
 Security commands for odahuflow cli
 """
 import logging
-import sys
 
 import click
 from click import UsageError

--- a/packages/cli/tests/parsers/test_security.py
+++ b/packages/cli/tests/parsers/test_security.py
@@ -1,0 +1,40 @@
+#  Copyright 2020 EPAM Systems
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from unittest.mock import Mock
+from click.testing import CliRunner
+from pytest_mock import MockFixture
+from odahuflow.cli.parsers import security
+from odahuflow.sdk.clients.api import APIConnectionException
+
+
+# TODO: Write a complete set of unit tests for security module
+
+def test_login_invalid_url(cli_runner: CliRunner, mocker: MockFixture):
+    """
+    Tests fix for issue #257 (https://github.com/odahu/odahu-flow/issues/257)
+    If
+    :param cli_runner: Click CLI runner fixture
+    :param mocker: pytest mocker fixture
+    """
+
+    mocker.patch.object(security, 'update_config_file')
+
+    api_client_class_mock: Mock = mocker.patch.object(security.api, 'RemoteAPIClient')
+    api_client: Mock = api_client_class_mock.return_value
+    api_client.info.side_effect = APIConnectionException
+
+    result = cli_runner.invoke(security.login, ['--url', '--help'])
+    assert result.exit_code != 0
+    assert isinstance(result.exception, APIConnectionException)

--- a/packages/sdk/odahuflow/sdk/clients/api.py
+++ b/packages/sdk/odahuflow/sdk/clients/api.py
@@ -506,8 +506,8 @@ class RemoteAPIClient:
         """
         try:
             return self.query("/health")
-        except ValueError:
-            pass
+        except ValueError as e:
+            raise APIConnectionException(*e.args)
 
 
 class AsyncRemoteAPIClient:


### PR DESCRIPTION
In the initial issue #257 @BPylypenko wrote that expected behavior is displaying help for command like this: `login --url --help`. From where I stand, taking `--help` as a URL is natural, it is expected behavior of `click` library. Everything that follows a non-flag option (that expects a value) is considered the value. Instead of hacking this behavior it was decided to validate URL after discussion with @vlad-tokarev.

**Change notes:** 
- I changed `RemoteAPIClient:info()` to wrap exceptions from `requests` library into `APIConnectionException` and raise up. 
- I wrote a simple unit test that simulates calling `login --url --help` from #257. But as far as I understand currently we don't have any other unit tests for login section. **Should I create a task to add them?**
- I added a minor change that is not directly connected to the issue #257. Specifically, I unified all entrypoints to be `cli.main.main()`. The only difference is that `cli.main.main()` handles exceptions and displays a corresponding error with exit code 1. It is a small change for development convenience so I included it to this PR. **Should I leave it here or create a separate PR for it?**