### PR TITLE
Fix/208 convert output dir

### DIFF
--- a/packages/cli/odahuflow/cli/parsers/local/__init__.py
+++ b/packages/cli/odahuflow/cli/parsers/local/__init__.py
@@ -17,8 +17,8 @@
 Group of local commands
 """
 import click
-from odahuflow.cli.parsers.local.packaging import packaging
-from odahuflow.cli.parsers.local.training import training
+from odahuflow.cli.parsers.local.packaging import packaging_group
+from odahuflow.cli.parsers.local.training import training_group
 from odahuflow.cli.utils.abbr import AbbreviationGroup
 
 
@@ -31,8 +31,8 @@ def local():
 
 
 LOCAL_GROUPS = [
-    training,
-    packaging,
+    training_group,
+    packaging_group,
 ]
 
 # Initialize local groups

--- a/packages/cli/odahuflow/cli/parsers/local/packaging.py
+++ b/packages/cli/odahuflow/cli/parsers/local/packaging.py
@@ -33,11 +33,11 @@ from odahuflow.sdk.models import K8sPackager, ModelPackaging, PackagingIntegrati
 LOGGER = logging.getLogger(__name__)
 
 
-@click.group()
+@click.group('packaging')
 @click.option('--url', help='API server host', default=config.API_URL)
 @click.option('--token', help='API server jwt token', default=config.API_TOKEN)
 @click.pass_context
-def packaging(ctx: click.core.Context, url: str, token: str):
+def packaging_group(ctx: click.core.Context, url: str, token: str):
     """
     Local packaging process.\n
     Alias for the command is pack.
@@ -45,7 +45,7 @@ def packaging(ctx: click.core.Context, url: str, token: str):
     ctx.obj = ModelPackagingClient(url, token)
 
 
-@packaging.command('cleanup-containers')
+@packaging_group.command('cleanup-containers')
 def cleanup_containers():
     """
     \b
@@ -58,7 +58,7 @@ def cleanup_containers():
     cleanup_packaging_docker_containers()
 
 
-@packaging.command()
+@packaging_group.command()
 @click.option('--pack-id', '--id', help='Model packaging ID', required=True)
 @click.option('--manifest-file', '-f', type=click.Path(), multiple=True,
               help='Path to a ODAHU-flow manifest file')

--- a/packages/cli/odahuflow/cli/parsers/local/packaging.py
+++ b/packages/cli/odahuflow/cli/parsers/local/packaging.py
@@ -33,7 +33,7 @@ from odahuflow.sdk.models import K8sPackager, ModelPackaging, PackagingIntegrati
 LOGGER = logging.getLogger(__name__)
 
 
-@click.group('packaging')
+@click.group(name='packaging')
 @click.option('--url', help='API server host', default=config.API_URL)
 @click.option('--token', help='API server jwt token', default=config.API_TOKEN)
 @click.pass_context

--- a/packages/cli/odahuflow/cli/parsers/local/training.py
+++ b/packages/cli/odahuflow/cli/parsers/local/training.py
@@ -36,11 +36,11 @@ from odahuflow.sdk.models import ToolchainIntegration, K8sTrainer
 LOGGER = logging.getLogger(__name__)
 
 
-@click.group()
+@click.group(name='training')
 @click.option('--url', help='API server host', default=config.API_URL)
 @click.option('--token', help='API server jwt token', default=config.API_TOKEN)
 @click.pass_context
-def training(ctx: click.core.Context, url: str, token: str):
+def training_group(ctx: click.core.Context, url: str, token: str):
     """
     Local training process.\n
     Alias for the command is train.
@@ -48,7 +48,7 @@ def training(ctx: click.core.Context, url: str, token: str):
     ctx.obj = ModelTrainingClient(url, token)
 
 
-@training.command("list")
+@training_group.command("list")
 @click.option('--output-format', '-o', 'output_format',
               default=PLAIN_TEXT_OUTPUT_FORMAT, type=click.Choice([PLAIN_TEXT_OUTPUT_FORMAT, JSON_OUTPUT_FORMAT]))
 def training_list(output_format: str):
@@ -79,7 +79,7 @@ def training_list(output_format: str):
             click.echo(f'* {artifact}')
 
 
-@training.command('cleanup-artifacts')
+@training_group.command('cleanup-artifacts')
 def cleanup_artifacts():
     """
     \b
@@ -92,7 +92,7 @@ def cleanup_artifacts():
     cleanup_local_artifacts()
 
 
-@training.command('cleanup-containers')
+@training_group.command('cleanup-containers')
 def cleanup_containers():
     """
     \b
@@ -105,14 +105,14 @@ def cleanup_containers():
     cleanup_training_docker_containers()
 
 
-@training.command()
+@training_group.command()
 @click.option('--train-id', '--id', help='Model training ID', required=True)
 @click.option('--manifest-file', '-f', type=click.Path(), multiple=True,
               help='Path to a ODAHU-flow manifest file')
 @click.option('--manifest-dir', '-d', type=click.Path(), multiple=True,
               help='Path to a directory with ODAHU-flow manifest files')
-@click.option('--output-dir', '--output', type=click.Path(), help='Directory where model artifact will be saved.\
-                                                                  Training artifact name would be the same as the dir.')
+@click.option('--output-dir', '--output', type=click.Path(),
+              help='Directory where model artifact will be saved. Training artifact name would be the same as the dir.')
 @pass_obj
 def run(client: ModelTrainingClient, train_id: str, manifest_file: List[str], manifest_dir: List[str],
         output_dir: str):

--- a/packages/cli/tests/parsers/test_local.py
+++ b/packages/cli/tests/parsers/test_local.py
@@ -81,5 +81,5 @@ def test_local_training_relative_output_dir(mocker: MockFixture, cli_runner: Cli
 
         for call in docker_mock.containers.run.call_args_list:
             mounts: List[Mount] = call.kwargs.get('mounts', [])
-            for mount in filter(lambda mount: mount.get('Target') == MODEL_OUTPUT_CONTAINER_PATH, mounts):
+            for mount in filter(lambda m: m.get('Target') == MODEL_OUTPUT_CONTAINER_PATH, mounts):
                 assert mount.get('Source') == abs_path

--- a/packages/cli/tests/parsers/test_local.py
+++ b/packages/cli/tests/parsers/test_local.py
@@ -79,7 +79,11 @@ def test_local_training_relative_output_dir(mocker: MockFixture, cli_runner: Cli
 
         abs_path = os.path.abspath(temp_dir)
 
+        print(f'call args list: {docker_mock.containers.run.call_args_list}')
         for call in docker_mock.containers.run.call_args_list:
+            print(f'call kwargs: {call.kwargs}')
+            print(f'call kwargs type: {type(call.kwargs)}')
             mounts: List[Mount] = call.kwargs.get('mounts', [])
+            print(mounts)
             for mount in filter(lambda m: m.get('Target') == MODEL_OUTPUT_CONTAINER_PATH, mounts):
                 assert mount.get('Source') == abs_path

--- a/packages/cli/tests/parsers/test_local.py
+++ b/packages/cli/tests/parsers/test_local.py
@@ -79,13 +79,9 @@ def test_local_training_relative_output_dir(mocker: MockFixture, cli_runner: Cli
 
         abs_path = os.path.abspath(temp_dir)
 
-        print(f'call args list: {docker_mock.containers.run.call_args_list}')
         for call in docker_mock.containers.run.call_args_list:
-            print(f'call: {call}, call type: {type(call)}, dir(call): {dir(call)}')
-            print(f'call kwargs: {call.kwargs}, call kwargs type: {type(call.kwargs)}')
-            print(f'call kwargs type: {type(call.kwargs)}')
-            mounts: List[Mount] = call.kwargs.get('mounts', [])
-            print(f'mounts object: {mounts}, type: {type(mounts)}')
+            call_kwargs = call[1]
+            mounts: List[Mount] = call_kwargs.get('mounts', [])
 
             for mount in filter(lambda m: m.get('Target') == MODEL_OUTPUT_CONTAINER_PATH, mounts):
                 assert mount.get('Source') == abs_path

--- a/packages/cli/tests/parsers/test_local.py
+++ b/packages/cli/tests/parsers/test_local.py
@@ -1,5 +1,18 @@
-from unittest.mock import patch
-from odahuflow.sdk.local.training import list_local_trainings
+import json
+import os
+import pathlib
+import tempfile
+from typing import List
+from unittest.mock import patch, Mock
+
+from click.testing import CliRunner, Result
+from docker.types import Mount
+from pytest_mock import MockFixture
+
+from odahuflow.cli.parsers.local import training
+from odahuflow.sdk.local import training as training_sdk
+from odahuflow.sdk.local.training import MODEL_OUTPUT_CONTAINER_PATH
+from odahuflow.sdk.models import ModelTraining, ToolchainIntegration, ModelTrainingSpec
 
 
 def test_list_local_trainings(tmpdir):
@@ -14,7 +27,7 @@ def test_list_local_trainings(tmpdir):
     for folder in folders:
         tmpdir.mkdir(folder)
     with patch('odahuflow.sdk.local.training.config.LOCAL_MODEL_OUTPUT_DIR', tmpdir):
-        assert list_local_trainings() == ['&wine-1-12',
+        assert training_sdk.list_local_trainings() == ['&wine-1-12',
                                           '2Wine-1@-12',
                                           '@wine-1@-12',
                                           'Awine-1@',
@@ -22,3 +35,51 @@ def test_list_local_trainings(tmpdir):
                                           '[wine-1@-12',
                                           'wine-1@-12',
                                           'zine-1@-12']
+
+
+def test_local_training_relative_output_dir(mocker: MockFixture, cli_runner: CliRunner):
+    """
+    Tests issue #208 - Converting relative path to output-dir to absolute,
+    because Docker requires mount paths to be absolute
+    :param mocker: mocker fixture
+    :param cli_runner: Click runner fixture
+    """
+
+    mocker.patch.object(training, 'K8sTrainer', autospec=True)
+    api_client = Mock()
+
+    mocker.patch.object(training_sdk, 'create_mt_config_file')
+    mocker.patch.object(training_sdk, 'stream_container_logs')
+    mocker.patch.object(training_sdk, 'raise_error_if_container_failed')
+
+    docker_mock: Mock = mocker.patch.object(training_sdk.docker, 'from_env').return_value
+    docker_mock.api.inspect_container = Mock(return_value={})
+
+    with tempfile.TemporaryDirectory(dir=os.curdir) as temp_dir:
+        temp_dir_path = pathlib.Path(temp_dir)
+        training_yml = temp_dir_path / 'training.yml'
+        training_yml.write_text(json.dumps(
+            {**ModelTraining(id='training1', spec=ModelTrainingSpec(toolchain='toolchain1')).to_dict(),
+             **{'kind': 'ModelTraining'}}))
+
+        toolchain_yml = temp_dir_path / 'toolchain.yml'
+        toolchain_yml.write_text(json.dumps({**ToolchainIntegration(id='toolchain1').to_dict(),
+                                             **{'kind': 'ToolchainIntegration'}}))
+
+        temp_dir_relative_path: str = os.path.relpath(temp_dir_path)
+
+        result: Result = cli_runner.invoke(
+            training.training_group,
+            ['run', '--output-dir', temp_dir_relative_path, '--manifest-file', str(training_yml),
+             '--manifest-file', str(toolchain_yml), '--id', 'training1'],
+            obj=api_client)
+
+        assert result.exit_code == 0, f'command invocation ended with exit code {result.exit_code}'
+        assert result.exception is None, f'command invocation ended with exception {result.exception}'
+
+        abs_path = os.path.abspath(temp_dir)
+
+        for call in docker_mock.containers.run.call_args_list:
+            mounts: List[Mount] = call.kwargs.get('mounts', [])
+            for mount in filter(lambda mount: mount.get('Target') == MODEL_OUTPUT_CONTAINER_PATH, mounts):
+                assert mount.get('Source') == abs_path

--- a/packages/cli/tests/parsers/test_local.py
+++ b/packages/cli/tests/parsers/test_local.py
@@ -81,9 +81,11 @@ def test_local_training_relative_output_dir(mocker: MockFixture, cli_runner: Cli
 
         print(f'call args list: {docker_mock.containers.run.call_args_list}')
         for call in docker_mock.containers.run.call_args_list:
-            print(f'call kwargs: {call.kwargs}')
+            print(f'call: {call}, call type: {type(call)}, dir(call): {dir(call)}')
+            print(f'call kwargs: {call.kwargs}, call kwargs type: {type(call.kwargs)}')
             print(f'call kwargs type: {type(call.kwargs)}')
             mounts: List[Mount] = call.kwargs.get('mounts', [])
-            print(mounts)
+            print(f'mounts object: {mounts}, type: {type(mounts)}')
+
             for mount in filter(lambda m: m.get('Target') == MODEL_OUTPUT_CONTAINER_PATH, mounts):
                 assert mount.get('Source') == abs_path

--- a/packages/sdk/odahuflow/sdk/local/training.py
+++ b/packages/sdk/odahuflow/sdk/local/training.py
@@ -97,7 +97,11 @@ def create_mt_config_file(trainer: K8sTrainer) -> None:
         LOGGER.debug(f"Saved the trainer configuration:\n{json.dumps(trainer_dict, indent=2)}")
 
 
-def start_train(trainer: K8sTrainer, output_dir: str):
+def start_train(trainer: K8sTrainer, output_dir: str) -> None:
+    """
+    :param trainer: container object for all configuration objects of a training
+    :param output_dir: path to directory to save result artifact (relative or absolute)
+    """
     create_mt_config_file(trainer)
 
     if not output_dir:
@@ -111,6 +115,7 @@ def start_train(trainer: K8sTrainer, output_dir: str):
         LOGGER.debug(f'Output model training directory is not provided. Generate the directory: {output_dir}')
 
     os.makedirs(output_dir, exist_ok=True)
+    output_dir = os.path.abspath(output_dir)
 
     launch_training_container(trainer, output_dir)
 


### PR DESCRIPTION
Change notes:
1. Converting output_dir to absolute path, as required by Docker for mount paths
1. Renamed click groups `local training` and `local packaging` to avoid naming conflicts with their modules. Example: now `training()` group is in `training.py` module which is a part of `local` package. `local.__init__.py` imports `training()` from `training.py`. So there's no easy way to import `training` module. `training()` object from `local.__init__.py` is imported instead. Renaming allows to handle this case.

Fixes #208.