### PR TITLE
[#193] Fixed local training to consider artifactNameTemplate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ helm-delete:
 ## install-python-linter: Install python test dependencies
 install-python-linter:
 	pip install pipenv pylint
-	cd containers/robot-tests && pipenv install --system --three --dev
+	cd packages/cli && pipenv install --system --three --dev
 
 ## python-lint: Lints python source code
 python-lint:

--- a/packages/cli/tests/parsers/test_local.py
+++ b/packages/cli/tests/parsers/test_local.py
@@ -45,7 +45,8 @@ def test_local_training_relative_output_dir(mocker: MockFixture, cli_runner: Cli
     :param cli_runner: Click runner fixture
     """
 
-    mocker.patch.object(training, 'K8sTrainer', autospec=True)
+    trainer_mock = mocker.patch.object(training, 'K8sTrainer', autospec=True).return_value
+    trainer_mock.model_training.spec.model.artifact_name_template = 'model_dir_template'
     api_client = Mock()
 
     mocker.patch.object(training_sdk, 'create_mt_config_file')
@@ -84,4 +85,4 @@ def test_local_training_relative_output_dir(mocker: MockFixture, cli_runner: Cli
             mounts: List[Mount] = call_kwargs.get('mounts', [])
 
             for mount in filter(lambda m: m.get('Target') == MODEL_OUTPUT_CONTAINER_PATH, mounts):
-                assert mount.get('Source') == abs_path
+                assert os.path.dirname(mount.get('Source')) == abs_path

--- a/packages/sdk/odahuflow/sdk/local/training.py
+++ b/packages/sdk/odahuflow/sdk/local/training.py
@@ -1,16 +1,18 @@
-import datetime
 import json
 import logging
 import os
+import re
+import uuid
+from collections import namedtuple
 from os import listdir
-from os.path import join
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 from shutil import rmtree
 from typing import List
 
 import docker
 from docker.models.containers import Container
 from docker.types import Mount
+
 from odahuflow.sdk import config
 from odahuflow.sdk.local.docker_utils import stream_container_logs, TRAINING_DOCKER_LABELS, WORKSPACE_PATH, \
     convert_labels_to_filter, cleanup_docker_containers, raise_error_if_container_failed
@@ -20,6 +22,27 @@ MODEL_OUTPUT_CONTAINER_PATH = '/output'
 TRAINER_CONF_PATH = 'mt.json'
 
 LOGGER = logging.getLogger(__name__)
+
+
+# Context object for compiling result model directory name from Go template
+TemplateContext = namedtuple('TemplateContext', ['Name', 'Version', 'RandomUUID'])
+
+DEFAULT_MODEL_DIR_TEMPLATE = '{{ .Name }}-{{ .Version }}-{{ .RandomUUID }}'
+
+
+def compile_artifact_name_template(go_template: str, context: TemplateContext) -> str:
+    """
+    Converts artifact name template from Go to Python format and compiles it
+    :param go_template: result model directory name template, e.g. {{ .Name }}-{{ .Version}}-{{ .RandomUUID }}
+    :param context: contains values to put into template
+    :return: compiled directory name
+    """
+
+    # Go -> Python template conversion
+    py_template = re.sub(r'{{\s*?\.([a-zA-Z_0-9]+)\s*?}}',
+                         lambda x: f'{{ctx.{x.group(1)}}}',
+                         go_template)
+    return py_template.format(ctx=context)
 
 
 def launch_training_container(trainer: K8sTrainer, output_dir: str) -> None:
@@ -101,22 +124,27 @@ def start_train(trainer: K8sTrainer, output_dir: str):
     create_mt_config_file(trainer)
 
     if not output_dir:
-        # For example, 01-Mar-2020-17-38-04
-        suffix = datetime.datetime.now().strftime("%d-%b-%Y-%H-%M-%S")
-        output_dir = join(
-            config.LOCAL_MODEL_OUTPUT_DIR,
-            f'{trainer.model_training.spec.model.name}-{trainer.model_training.spec.model.version}-{suffix}'
-        )
+        output_dir = config.LOCAL_MODEL_OUTPUT_DIR
+        LOGGER.debug(f'Output directory for model training is not provided. Using default: {output_dir}')
 
-        LOGGER.debug(f'Output model training directory is not provided. Generate the directory: {output_dir}')
+    model_dir_name_template = trainer.model_training.spec.model.artifact_name_template or DEFAULT_MODEL_DIR_TEMPLATE
 
-    os.makedirs(output_dir, exist_ok=True)
+    model_dir_name_template = model_dir_name_template.rstrip('.zip')
 
-    launch_training_container(trainer, output_dir)
+    model_dir_name = compile_artifact_name_template(
+        go_template=model_dir_name_template,
+        context=TemplateContext(Name=trainer.model_training.spec.model.name,
+                                Version=trainer.model_training.spec.model.version,
+                                RandomUUID=uuid.uuid4())
+    )
 
-    launch_gppi_validation_container(trainer, output_dir)
+    model_dir_path = os.path.join(output_dir, model_dir_name)
+    os.makedirs(model_dir_path, exist_ok=True)
 
-    print(f'Model {Path(output_dir).name} was saved in the {output_dir} directory')
+    launch_training_container(trainer, model_dir_path)
+    launch_gppi_validation_container(trainer, model_dir_path)
+
+    print(f'Model {model_dir_name} was saved in the {output_dir} directory')
 
 
 def list_local_trainings() -> List[str]:

--- a/packages/sdk/odahuflow/sdk/local/training.py
+++ b/packages/sdk/odahuflow/sdk/local/training.py
@@ -129,7 +129,10 @@ def start_train(trainer: K8sTrainer, output_dir: str):
 
     model_dir_name_template = trainer.model_training.spec.model.artifact_name_template or DEFAULT_MODEL_DIR_TEMPLATE
 
-    model_dir_name_template = model_dir_name_template.rstrip('.zip')
+    # Removing .zip extension if there's one
+    model_dir_name_template = model_dir_name_template.strip()
+    if model_dir_name_template.endswith('.zip'):
+        model_dir_name_template = model_dir_name_template[:-4]
 
     model_dir_name = compile_artifact_name_template(
         go_template=model_dir_name_template,

--- a/packages/sdk/tests/local/__init__.py
+++ b/packages/sdk/tests/local/__init__.py
@@ -11,4 +11,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-

--- a/packages/sdk/tests/local/__init__.py
+++ b/packages/sdk/tests/local/__init__.py
@@ -1,0 +1,14 @@
+#  Copyright 2020 EPAM Systems
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+

--- a/packages/sdk/tests/local/test_local_training.py
+++ b/packages/sdk/tests/local/test_local_training.py
@@ -37,7 +37,7 @@ test_data = [
         'model_name-99-uuid_here'
     ),
     (
-        'Model {{ .Name }}',
+        'Model {{   .Name      }}',
         TemplateContext(Name=None, Version=None, RandomUUID=None),
         'Model None'
     )
@@ -85,7 +85,8 @@ def test_start_training__output_dir(output_dir: Optional[str], expected_output_d
 @pytest.mark.parametrize(['template', 'expected_template'],
                          [(None, DEFAULT_MODEL_DIR_TEMPLATE),
                           ('{{ .Prop1 }}__{{ .prop2 }}', '{{ .Prop1 }}__{{ .prop2 }}'),
-                          ('{{ .Prop1 }}_abc.zip', '{{ .Prop1 }}_abc')]
+                          ('{{ .Prop1 }}_abc.zip', '{{ .Prop1 }}_abc'),
+                          ('{{ .Prop1 }}_fizz.zip.zip', '{{ .Prop1 }}_fizz.zip')],
                          )
 def test_start_training__artifact_name_template(template: Optional[str],
                                                 expected_template: str, mocker: MockFixture):

--- a/packages/sdk/tests/local/test_local_training.py
+++ b/packages/sdk/tests/local/test_local_training.py
@@ -86,7 +86,7 @@ def test_start_training__output_dir(output_dir: Optional[str], expected_output_d
                          [(None, DEFAULT_MODEL_DIR_TEMPLATE),
                           ('{{ .Prop1 }}__{{ .prop2 }}', '{{ .Prop1 }}__{{ .prop2 }}'),
                           ('{{ .Prop1 }}_abc.zip', '{{ .Prop1 }}_abc'),
-                          ('{{ .Prop1 }}_fizz.zip.zip', '{{ .Prop1 }}_fizz.zip')],
+                          (' {{ .Prop1   }}_fizz.zip.zip  ', '{{ .Prop1   }}_fizz.zip')],
                          )
 def test_start_training__artifact_name_template(template: Optional[str],
                                                 expected_template: str, mocker: MockFixture):

--- a/packages/sdk/tests/local/test_local_training.py
+++ b/packages/sdk/tests/local/test_local_training.py
@@ -1,0 +1,117 @@
+#  Copyright 2020 EPAM Systems
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+from typing import Optional
+from unittest.mock import ANY
+
+import pytest
+from pytest_mock import MockFixture
+
+from odahuflow.sdk.local import training
+from odahuflow.sdk.local.training import compile_artifact_name_template, TemplateContext, start_train, \
+    DEFAULT_MODEL_DIR_TEMPLATE
+from odahuflow.sdk.models import K8sTrainer, ModelTraining, ModelTrainingSpec, ModelIdentity
+
+
+# Format: [(template, context, expected_result), ...]
+test_data = [
+    (
+        '{{ .Name }}_abc_{{ .RandomUUID }}',
+        TemplateContext(Name='wine', Version='2.3', RandomUUID='123-123'),
+        'wine_abc_123-123'
+    ),
+    (
+        '{{ .Name }}-{{ .Version }}-{{ .RandomUUID }}',
+        TemplateContext(Name='model_name', Version='99', RandomUUID='uuid_here'),
+        'model_name-99-uuid_here'
+    ),
+    (
+        'Model {{ .Name }}',
+        TemplateContext(Name=None, Version=None, RandomUUID=None),
+        'Model None'
+    )
+]
+
+
+@pytest.mark.parametrize(['template', 'ctx', 'expected'], test_data)
+def test_compile_artifact_name_template(template, ctx, expected):
+    assert compile_artifact_name_template(template, ctx) == expected
+
+
+DEFAULT_OUTPUT_DIR = '/odahu/default_output'
+
+
+@pytest.mark.parametrize(['output_dir', 'expected_output_dir'],
+                         [(None, DEFAULT_OUTPUT_DIR),
+                          ('/custom/output', '/custom/output')]
+                         )
+def test_start_training__output_dir(output_dir: Optional[str], expected_output_dir: str, mocker: MockFixture):
+    """
+    Tests output_dir parameter. If it is provided, the result model directory is created under it.
+    Otherwise, it is created in a default output path from config
+    """
+    trainer = K8sTrainer(model_training=ModelTraining(spec=ModelTrainingSpec(model=ModelIdentity())))
+
+    mocker.patch.object(training, 'create_mt_config_file')
+    config_mock = mocker.patch.object(training, 'config')
+    os_makedirs_mock = mocker.patch.object(training.os, 'makedirs')
+    compile_artifact_name_template_mock = mocker.patch.object(training, 'compile_artifact_name_template')
+    launch_training_container_mock = mocker.patch.object(training, 'launch_training_container')
+    launch_gppi_validation_container_mock = mocker.patch.object(training, 'launch_gppi_validation_container')
+
+    config_mock.LOCAL_MODEL_OUTPUT_DIR = DEFAULT_OUTPUT_DIR
+    compile_artifact_name_template_mock.return_value = 'model_dir_name'
+
+    start_train(trainer, output_dir)
+
+    expected_model_dir_path = os.path.join(expected_output_dir, 'model_dir_name')
+
+    os_makedirs_mock.assert_called_with(expected_model_dir_path, exist_ok=ANY)
+    launch_training_container_mock.assert_called_with(trainer, expected_model_dir_path)
+    launch_gppi_validation_container_mock.assert_called_with(trainer, expected_model_dir_path)
+
+
+@pytest.mark.parametrize(['template', 'expected_template'],
+                         [(None, DEFAULT_MODEL_DIR_TEMPLATE),
+                          ('{{ .Prop1 }}__{{ .prop2 }}', '{{ .Prop1 }}__{{ .prop2 }}'),
+                          ('{{ .Prop1 }}_abc.zip', '{{ .Prop1 }}_abc')]
+                         )
+def test_start_training__artifact_name_template(template: Optional[str],
+                                                expected_template: str, mocker: MockFixture):
+    """
+    Tests artifactNameTemplate property from training configuration. If it is provided,
+    the result model directory is named according to it. Otherwise, the default template is used.
+    If artifact name template ends with .zip it is trimmed.
+    """
+    model = ModelIdentity(artifact_name_template=template)
+    trainer = K8sTrainer(model_training=ModelTraining(spec=ModelTrainingSpec(model=model)))
+
+    mocker.patch.object(training, 'create_mt_config_file')
+    os_makedirs_mock = mocker.patch.object(training.os, 'makedirs')
+    compile_artifact_name_template_mock = mocker.patch.object(training, 'compile_artifact_name_template')
+    launch_training_container_mock = mocker.patch.object(training, 'launch_training_container')
+    launch_gppi_validation_container_mock = mocker.patch.object(training, 'launch_gppi_validation_container')
+
+    compile_artifact_name_template_mock.return_value = 'compiled_model_dir_name'
+
+    output_dir = '/test/output'
+    start_train(trainer, output_dir)
+
+    compile_artifact_name_template_mock.assert_called_with(go_template=expected_template, context=ANY)
+
+    expected_model_dir_path = os.path.join(output_dir, 'compiled_model_dir_name')
+
+    os_makedirs_mock.assert_called_with(expected_model_dir_path, exist_ok=ANY)
+    launch_training_container_mock.assert_called_with(trainer, expected_model_dir_path)
+    launch_gppi_validation_container_mock.assert_called_with(trainer, expected_model_dir_path)


### PR DESCRIPTION
Fixes #193. Original issue is that `local training` does not consider `artifactNameTemplate` from training configuration. Instead it saves the output model files into `--output-dir` if it is provided. Otherwise it defaults to `$HOME/.odahuflow/<name>-<version>-datetime/ directory.

I suggest to change the behavior to the following:
- result model's files are saved to the directory which is named according to the `artifactNameTemplate`. If the template is not provided it defaults to `'{{ .Name }}-{{ .Version }}-{{ .RandomUUID }}'`;
- this directory will be saved under the path provided via `--output-dir` or in `config.LOCAL_MODEL_OUTPUT_DIR` by default.
You can check tests out to see it in action.

By example:
before: /path/to/output_dir/ contains model files
after: /path/to/output_dir/directory_named_by_artifactNameTemplate/ contains model files

**Another change in this PR** is in `Makefile`. For some reason until now dependencies for linting job were installed from `/containers/robot-tests` which makes no sense to me. It produced linter errors, since `pylint` could not find dev-dependencies used in tests (such as `pytest_mock`). I changed it to the path containing a good `Pipfile` and errors are gone. Am I right or missing something here?