### PR TITLE
Fix #202: mask secrets in connection creation response

### DIFF
--- a/packages/operator/pkg/apis/connection/connection.go
+++ b/packages/operator/pkg/apis/connection/connection.go
@@ -25,7 +25,7 @@ const (
 	GITType           = v1alpha1.ConnectionType("git")
 	DockerType        = v1alpha1.ConnectionType("docker")
 	EcrType           = v1alpha1.ConnectionType("ecr")
-	decryptedDataMask = "*****"
+	DecryptedDataMask = "*****"
 )
 
 var (
@@ -53,15 +53,15 @@ type Connection struct {
 // Replace sensitive data with mask in the connection
 func (c *Connection) DeleteSensitiveData() *Connection {
 	if len(c.Spec.Password) != 0 {
-		c.Spec.Password = decryptedDataMask
+		c.Spec.Password = DecryptedDataMask
 	}
 
 	if len(c.Spec.KeySecret) != 0 {
-		c.Spec.KeySecret = decryptedDataMask
+		c.Spec.KeySecret = DecryptedDataMask
 	}
 
 	if len(c.Spec.KeyID) != 0 {
-		c.Spec.KeyID = decryptedDataMask
+		c.Spec.KeyID = DecryptedDataMask
 	}
 
 	return c

--- a/packages/operator/pkg/apis/connection/connection.go
+++ b/packages/operator/pkg/apis/connection/connection.go
@@ -66,3 +66,8 @@ func (c *Connection) DeleteSensitiveData() *Connection {
 
 	return c
 }
+
+// The wrapper around DeleteSensitiveData, but it doesn't mutate the original object and returns a copy
+func (c Connection) DeleteSensitiveDataImmutable() *Connection {
+	return c.DeleteSensitiveData()
+}

--- a/packages/operator/pkg/repository/connection/http/connection.go
+++ b/packages/operator/pkg/repository/connection/http/connection.go
@@ -126,12 +126,12 @@ func (hcr *httpConnectionRepository) DeleteConnection(id string) error {
 	panic("not implemented")
 }
 
-func (hcr *httpConnectionRepository) UpdateConnection(connection *connection.Connection) error {
+func (hcr *httpConnectionRepository) UpdateConnection(connection *connection.Connection) (*connection.Connection, error) {
 	panic("not implemented")
 
 }
 
-func (hcr *httpConnectionRepository) CreateConnection(connection *connection.Connection) error {
+func (hcr *httpConnectionRepository) CreateConnection(connection *connection.Connection) (*connection.Connection, error) {
 	panic("not implemented")
 
 }

--- a/packages/operator/pkg/repository/connection/http/connection.go
+++ b/packages/operator/pkg/repository/connection/http/connection.go
@@ -126,12 +126,12 @@ func (hcr *httpConnectionRepository) DeleteConnection(id string) error {
 	panic("not implemented")
 }
 
-func (hcr *httpConnectionRepository) UpdateConnection(connection *connection.Connection) (*connection.Connection, error) {
+func (hcr *httpConnectionRepository) UpdateConnection(connection *connection.Connection) (
+	*connection.Connection, error) {
 	panic("not implemented")
-
 }
 
-func (hcr *httpConnectionRepository) CreateConnection(connection *connection.Connection) (*connection.Connection, error) {
+func (hcr *httpConnectionRepository) CreateConnection(connection *connection.Connection) (
+	*connection.Connection, error) {
 	panic("not implemented")
-
 }

--- a/packages/operator/pkg/repository/connection/kubernetes/connection.go
+++ b/packages/operator/pkg/repository/connection/kubernetes/connection.go
@@ -187,7 +187,7 @@ func (kc *k8sConnectionRepository) UpdateConnection(conn *connection.Connection)
 
 	conn.Status = k8sConn.Status
 
-	return conn.DeleteSensitiveData(), nil
+	return conn.DeleteSensitiveDataImmutable(), nil
 }
 
 func (kc *k8sConnectionRepository) CreateConnection(connection *connection.Connection) (*connection.Connection, error) {
@@ -211,7 +211,7 @@ func (kc *k8sConnectionRepository) CreateConnection(connection *connection.Conne
 
 	connection.Status = conn.Status
 
-	return connection.DeleteSensitiveData(), nil
+	return connection.DeleteSensitiveDataImmutable(), nil
 }
 
 func convertK8sErrToOdahuflowErr(err error) error {

--- a/packages/operator/pkg/repository/connection/kubernetes/connection.go
+++ b/packages/operator/pkg/repository/connection/kubernetes/connection.go
@@ -163,7 +163,7 @@ func (kc *k8sConnectionRepository) DeleteConnection(id string) error {
 	return nil
 }
 
-func (kc *k8sConnectionRepository) UpdateConnection(conn *connection.Connection) error {
+func (kc *k8sConnectionRepository) UpdateConnection(conn *connection.Connection) (*connection.Connection, error) {
 	var k8sConn v1alpha1.Connection
 	if err := kc.k8sClient.Get(context.TODO(),
 		types.NamespacedName{Name: conn.ID, Namespace: kc.namespace},
@@ -171,7 +171,7 @@ func (kc *k8sConnectionRepository) UpdateConnection(conn *connection.Connection)
 	); err != nil {
 		logC.Error(err, "Get conn from k8s", "id", conn.ID)
 
-		return convertK8sErrToOdahuflowErr(err)
+		return nil, convertK8sErrToOdahuflowErr(err)
 	}
 
 	// TODO: think about update, not replacing as for now
@@ -182,15 +182,15 @@ func (kc *k8sConnectionRepository) UpdateConnection(conn *connection.Connection)
 	if err := kc.k8sClient.Update(context.TODO(), &k8sConn); err != nil {
 		logC.Error(err, "Creation of the conn", "id", conn.ID)
 
-		return convertK8sErrToOdahuflowErr(err)
+		return nil, convertK8sErrToOdahuflowErr(err)
 	}
 
 	conn.Status = k8sConn.Status
 
-	return nil
+	return conn.DeleteSensitiveData(), nil
 }
 
-func (kc *k8sConnectionRepository) CreateConnection(connection *connection.Connection) error {
+func (kc *k8sConnectionRepository) CreateConnection(connection *connection.Connection) (*connection.Connection, error) {
 	conn := &v1alpha1.Connection{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      connection.ID,
@@ -206,12 +206,12 @@ func (kc *k8sConnectionRepository) CreateConnection(connection *connection.Conne
 	if err := kc.k8sClient.Create(context.TODO(), conn); err != nil {
 		logC.Error(err, "ConnectionName creation error from k8s", "name", connection.ID)
 
-		return convertK8sErrToOdahuflowErr(err)
+		return nil, convertK8sErrToOdahuflowErr(err)
 	}
 
 	connection.Status = conn.Status
 
-	return nil
+	return connection.DeleteSensitiveData(), nil
 }
 
 func convertK8sErrToOdahuflowErr(err error) error {

--- a/packages/operator/pkg/repository/connection/kubernetes/connection_test.go
+++ b/packages/operator/pkg/repository/connection/kubernetes/connection_test.go
@@ -40,7 +40,8 @@ func TestConnectionRepository(t *testing.T) {
 		},
 	}
 
-	g.Expect(c.CreateConnection(created)).NotTo(HaveOccurred())
+	_, err := c.CreateConnection(created)
+	g.Expect(err).NotTo(HaveOccurred())
 
 	fetched, err := c.GetDecryptedConnection(connID)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -59,7 +60,8 @@ func TestConnectionRepository(t *testing.T) {
 			Type: newConnType,
 		},
 	}
-	g.Expect(c.UpdateConnection(updated)).NotTo(HaveOccurred())
+	_, err = c.UpdateConnection(updated)
+	g.Expect(err).NotTo(HaveOccurred())
 
 	fetched, err = c.GetConnection(connID)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/packages/operator/pkg/repository/connection/repository.go
+++ b/packages/operator/pkg/repository/connection/repository.go
@@ -29,8 +29,8 @@ type Repository interface {
 	GetDecryptedConnection(id string) (*connection.Connection, error)
 	GetConnectionList(options ...ListOption) ([]connection.Connection, error)
 	DeleteConnection(id string) error
-	UpdateConnection(connection *connection.Connection) error
-	CreateConnection(connection *connection.Connection) error
+	UpdateConnection(connection *connection.Connection) (*connection.Connection, error)
+	CreateConnection(connection *connection.Connection) (*connection.Connection, error)
 }
 
 type Filter struct {

--- a/packages/operator/pkg/repository/connection/vault/connection.go
+++ b/packages/operator/pkg/repository/connection/vault/connection.go
@@ -164,7 +164,7 @@ func (vcr *vaultConnRepository) UpdateConnection(conn *connection.Connection) (*
 		if err != nil {
 			conn.Status = existedConn.Status
 		}
-		return conn.DeleteSensitiveData(), err
+		return conn.DeleteSensitiveDataImmutable(), err
 	case odahuflow_errors.IsNotFoundError(err):
 		return nil, odahuflow_errors.NotFoundError{Entity: conn.ID}
 	default:
@@ -182,7 +182,7 @@ func (vcr *vaultConnRepository) CreateConnection(conn *connection.Connection) (*
 	case odahuflow_errors.IsNotFoundError(err):
 		conn.Status.CreatedAt = &metav1.Time{Time: time.Now()}
 		conn.Status.UpdatedAt = &metav1.Time{Time: time.Now()}
-		return conn.DeleteSensitiveData(), vcr.createOrUpdateConnection(conn)
+		return conn.DeleteSensitiveDataImmutable(), vcr.createOrUpdateConnection(conn)
 	default:
 		return nil, err
 	}

--- a/packages/operator/pkg/repository/connection/vault/connection_test.go
+++ b/packages/operator/pkg/repository/connection/vault/connection_test.go
@@ -99,7 +99,8 @@ func (s *VaultConnRepoSuite) TestConnectionRepository() {
 		},
 	}
 
-	s.g.Expect(s.connRepo.CreateConnection(created)).NotTo(HaveOccurred())
+	_, err := s.connRepo.CreateConnection(created)
+	s.g.Expect(err).NotTo(HaveOccurred())
 
 	fetched, err := s.connRepo.GetDecryptedConnection(connID)
 	s.g.Expect(err).NotTo(HaveOccurred())
@@ -118,7 +119,9 @@ func (s *VaultConnRepoSuite) TestConnectionRepository() {
 			Type: newConnType,
 		},
 	}
-	s.g.Expect(s.connRepo.UpdateConnection(updated)).NotTo(HaveOccurred())
+
+	_, err = s.connRepo.UpdateConnection(updated)
+	s.g.Expect(err).NotTo(HaveOccurred())
 
 	fetched, err = s.connRepo.GetConnection(connID)
 	s.g.Expect(err).NotTo(HaveOccurred())

--- a/packages/operator/pkg/webserver/routes/v1/connection/connection_routes.go
+++ b/packages/operator/pkg/webserver/routes/v1/connection/connection_routes.go
@@ -191,14 +191,16 @@ func (cc *controller) createConnection(c *gin.Context) {
 		return
 	}
 
-	if err := cc.connRepository.CreateConnection(&conn); err != nil {
+	var createdConnection *connection.Connection
+	var err error
+	if createdConnection, err = cc.connRepository.CreateConnection(&conn); err != nil {
 		logC.Error(err, fmt.Sprintf("Creation of the connection: %+v", conn))
 		c.AbortWithStatusJSON(routes.CalculateHTTPStatusCode(err), routes.HTTPResult{Message: err.Error()})
 
 		return
 	}
 
-	c.JSON(http.StatusCreated, conn.DeleteSensitiveData())
+	c.JSON(http.StatusCreated, createdConnection)
 }
 
 // @Summary Update a Connection
@@ -228,14 +230,15 @@ func (cc *controller) updateConnection(c *gin.Context) {
 		return
 	}
 
-	if err := cc.connRepository.UpdateConnection(&conn); err != nil {
+	updatedConnection, err := cc.connRepository.UpdateConnection(&conn)
+	if err != nil {
 		logC.Error(err, fmt.Sprintf("Update of the connection: %+v", conn))
 		c.AbortWithStatusJSON(routes.CalculateHTTPStatusCode(err), routes.HTTPResult{Message: err.Error()})
 
 		return
 	}
 
-	c.JSON(http.StatusOK, conn)
+	c.JSON(http.StatusOK, updatedConnection)
 }
 
 // @Summary Delete a Connection

--- a/packages/operator/pkg/webserver/routes/v1/connection/connection_routes.go
+++ b/packages/operator/pkg/webserver/routes/v1/connection/connection_routes.go
@@ -198,7 +198,7 @@ func (cc *controller) createConnection(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusCreated, conn)
+	c.JSON(http.StatusCreated, conn.DeleteSensitiveData())
 }
 
 // @Summary Update a Connection

--- a/packages/operator/pkg/webserver/routes/v1/connection/connection_routes_test.go
+++ b/packages/operator/pkg/webserver/routes/v1/connection/connection_routes_test.go
@@ -360,7 +360,13 @@ func (s *ConnectionRouteGenericSuite) TestCreateConnection() {
 
 	s.g.Expect(http.StatusCreated).Should(Equal(w.Code))
 	s.g.Expect(connResponse.ID).Should(Equal(connEntity.ID))
-	s.g.Expect(connResponse.Spec).Should(Equal(connEntity.Spec))
+	s.g.Expect(connResponse.Spec.URI).To(Equal(connEntity.Spec.URI))
+	s.g.Expect(connResponse.Spec.Type).To(Equal(connEntity.Spec.Type))
+
+	// Verify that secrets are masked
+	s.g.Expect(connResponse.Spec.Password).Should(Or(BeEmpty(), Equal(connection.DecryptedDataMask)))
+	s.g.Expect(connResponse.Spec.KeySecret).Should(Or(BeEmpty(), Equal(connection.DecryptedDataMask)))
+	s.g.Expect(connResponse.Spec.KeyID).Should(Or(BeEmpty(), Equal(connection.DecryptedDataMask)))
 
 	conn, err := s.connRepository.GetConnection(connID)
 	s.g.Expect(err).ShouldNot(HaveOccurred())

--- a/packages/operator/pkg/webserver/routes/v1/packaging/model_packaging_test.go
+++ b/packages/operator/pkg/webserver/routes/v1/packaging/model_packaging_test.go
@@ -115,7 +115,7 @@ func (s *ModelPackagingRouteSuite) SetupSuite() {
 
 	s.connRepository = conn_k8s_repository.NewRepository(testNamespace, s.k8sClient)
 	// Create the connection that will be used as the outputConnection param for a training.
-	if err := s.connRepository.CreateConnection(&connection.Connection{
+	if _, err := s.connRepository.CreateConnection(&connection.Connection{
 		ID: testOutConn,
 		Spec: odahuflowv1alpha1.ConnectionSpec{
 			Type: connection.GcsType,
@@ -125,7 +125,7 @@ func (s *ModelPackagingRouteSuite) SetupSuite() {
 	}
 
 	// Create the connection that will be used as the default outputConnection param for a training.
-	if err := s.connRepository.CreateConnection(&connection.Connection{
+	if _, err := s.connRepository.CreateConnection(&connection.Connection{
 		ID: testOutConnDefault,
 		Spec: odahuflowv1alpha1.ConnectionSpec{
 			Type: connection.GcsType,

--- a/packages/operator/pkg/webserver/routes/v1/packaging/model_packaging_validation_test.go
+++ b/packages/operator/pkg/webserver/routes/v1/packaging/model_packaging_validation_test.go
@@ -158,7 +158,7 @@ func (s *ModelPackagingValidationSuite) SetupSuite() {
 		s.T().Fatal(err)
 	}
 
-	err = s.connRepository.CreateConnection(&connection.Connection{
+	_, err = s.connRepository.CreateConnection(&connection.Connection{
 		ID: connDockerTypeMpValid,
 		Spec: v1alpha1.ConnectionSpec{
 			Type: connection.DockerType,
@@ -169,7 +169,7 @@ func (s *ModelPackagingValidationSuite) SetupSuite() {
 		s.T().Fatal(err)
 	}
 
-	err = s.connRepository.CreateConnection(&connection.Connection{
+	_, err = s.connRepository.CreateConnection(&connection.Connection{
 		ID: connS3TypeMpValid,
 		Spec: v1alpha1.ConnectionSpec{
 			Type: connection.S3Type,

--- a/packages/operator/pkg/webserver/routes/v1/training/model_training_test.go
+++ b/packages/operator/pkg/webserver/routes/v1/training/model_training_test.go
@@ -70,7 +70,7 @@ func (s *ModelTrainingRouteSuite) SetupSuite() {
 	s.connRepository = conn_k8s_repository.NewRepository(testNamespace, s.k8sClient)
 
 	// Create the connection that will be used as the vcs param for a training.
-	if err := s.connRepository.CreateConnection(&connection.Connection{
+	if _, err := s.connRepository.CreateConnection(&connection.Connection{
 		ID: testMtVCSID,
 		Spec: odahuflowv1alpha1.ConnectionSpec{
 			Type:      connection.GITType,
@@ -93,7 +93,7 @@ func (s *ModelTrainingRouteSuite) SetupSuite() {
 	}
 
 	// Create the connection that will be used as the outputConnection param for a training.
-	if err := s.connRepository.CreateConnection(&connection.Connection{
+	if _, err := s.connRepository.CreateConnection(&connection.Connection{
 		ID: testMtOutConn,
 		Spec: odahuflowv1alpha1.ConnectionSpec{
 			Type: connection.GcsType,
@@ -104,7 +104,7 @@ func (s *ModelTrainingRouteSuite) SetupSuite() {
 	}
 
 	// Create the connection that will be used as the default outputConnection param for a training.
-	if err := s.connRepository.CreateConnection(&connection.Connection{
+	if _, err := s.connRepository.CreateConnection(&connection.Connection{
 		ID: testMtOutConnDefault,
 		Spec: odahuflowv1alpha1.ConnectionSpec{
 			Type: connection.GcsType,

--- a/packages/operator/pkg/webserver/routes/v1/training/model_training_validation_test.go
+++ b/packages/operator/pkg/webserver/routes/v1/training/model_training_validation_test.go
@@ -75,7 +75,7 @@ func (s *ModelTrainingValidationSuite) SetupSuite() {
 	)
 
 	// Create the connection that will be used as the vcs param for a training.
-	if err := s.connRepository.CreateConnection(&connection.Connection{
+	if _, err := s.connRepository.CreateConnection(&connection.Connection{
 		ID: testMtVCSID,
 		Spec: v1alpha1.ConnectionSpec{
 			Type:      connection.GITType,
@@ -188,7 +188,7 @@ func (s *ModelTrainingValidationSuite) TestMtNotExplicitMTReference() {
 		},
 	}
 
-	err := s.connRepository.CreateConnection(conn)
+	_, err := s.connRepository.CreateConnection(conn)
 	s.g.Expect(err).Should(BeNil())
 	defer s.connRepository.DeleteConnection(conn.ID)
 
@@ -222,7 +222,7 @@ func (s *ModelTrainingValidationSuite) TestMtWrongVcsConnectionType() {
 		},
 	}
 
-	err := s.connRepository.CreateConnection(conn)
+	_, err := s.connRepository.CreateConnection(conn)
 	s.g.Expect(err).Should(BeNil())
 	defer s.connRepository.DeleteConnection(conn.ID)
 


### PR DESCRIPTION
Fix #202. Original issue: when creating a connection, secrets are not masked in response connection object.

@vlad-tokarev since you're well-familiar with the project structure, I would appreciate your advice here regarding the following: I masked secrets on controller-level. It is super-easy one-line fix, **but** it is not completely consistent with the rest of code. In case of retrieving a connection with masked secrets masking takes place on repository-level. The repository has 2 methods: `GetConnection` and `GetDecryptedConnection`. So this masking logic (what to mask, what not to mask) gets spread a bit. 
Maybe I should refactor repository's `CreateConnection` so that it would return newly created masked **connection** and **error** instead of just error as it is now? Then masking would stay on repository level only, but it will require a bunch of refactoring - it is used a lot in tests.
What do you think?
