### PR TITLE
Decode base64 keySecret received from API in testing script

### DIFF
--- a/packages/tests/stuff/training_stuff.sh
+++ b/packages/tests/stuff/training_stuff.sh
@@ -106,7 +106,7 @@ function configure_rclone() {
     ;;
   azure)
     local sas_url
-    sas_url="$(odahuflowctl conn get --id models-output --decrypted -o json | jq -r '.[0].spec.keySecret')"
+    sas_url="$(odahuflowctl conn get --id models-output --decrypted -o json | jq -r '.[0].spec.keySecret' | base64 -d)"
 
     rclone config create "${RCLONE_PROFILE_NAME}" "azureblob" \
       sas_url "${sas_url}" \


### PR DESCRIPTION
`training_stuff.sh` script must decode keySecret from base64 before passwing it to rclone.

Because of that Azure tests failed. They passed well with this change.
https://jenkins.cicd.odahu.org/view/OdahuFlow%20Deploy/job/Azure_Create_cluster/525/robot/