### PR TITLE
added issuer_url parameter in RemoteAPIClient 

### DIFF
--- a/packages/cli/odahuflow/cli/parsers/security.py
+++ b/packages/cli/odahuflow/cli/parsers/security.py
@@ -84,9 +84,9 @@ def login(api_host: str, token: str, client_id: str, client_secret: str, issuer:
         # update config
         update_config_file(
             API_URL=api_host,
+            API_TOKEN=token,
             ODAHUFLOWCTL_OAUTH_CLIENT_ID=client_id,
             ODAHUFLOWCTL_OAUTH_CLIENT_SECRET=client_secret,
-            API_TOKEN=token,
             ISSUER_URL=issuer
         )
 

--- a/packages/cli/odahuflow/cli/parsers/security.py
+++ b/packages/cli/odahuflow/cli/parsers/security.py
@@ -21,7 +21,6 @@ import logging
 import click
 from click import UsageError
 
-import odahuflow.sdk.config as config
 from odahuflow.sdk.clients import api
 from odahuflow.sdk.config import update_config_file
 

--- a/packages/cli/odahuflow/cli/parsers/security.py
+++ b/packages/cli/odahuflow/cli/parsers/security.py
@@ -23,7 +23,6 @@ from click import UsageError
 
 import odahuflow.sdk.config as config
 from odahuflow.sdk.clients import api
-from odahuflow.sdk.clients.oidc import OpenIdProviderConfiguration
 from odahuflow.sdk.config import update_config_file
 
 LOG = logging.getLogger(__name__)
@@ -45,13 +44,6 @@ def _reset_credentials():
                        MODEL_HOST=None)
 
 
-def fetch_openid_conf(issuer: str) -> None:
-    conf = OpenIdProviderConfiguration(issuer)
-    conf.fetch_configuration()
-
-    config.API_ISSUING_URL = conf.token_endpoint
-
-
 @click.command()
 @click.option('--url', 'api_host', help='API server host', required=True)
 @click.option('--token', help='API server jwt token')
@@ -64,18 +56,6 @@ def login(api_host: str, token: str, client_id: str, client_secret: str, issuer:
     Check that credentials is correct and save to the config
     """
 
-    # clean config from previous credentials
-    _reset_credentials()
-
-    # update config
-    update_config_file(
-        API_URL=api_host,
-        ODAHUFLOWCTL_OAUTH_CLIENT_ID=client_id,
-        ODAHUFLOWCTL_OAUTH_CLIENT_SECRET=client_secret,
-        API_TOKEN=token,
-        ISSUER_URL=issuer
-    )
-
     # set predicates
     is_token_login = bool(token)
     is_client_cred_login = bool(client_id) or bool(client_secret)
@@ -87,19 +67,17 @@ def login(api_host: str, token: str, client_id: str, client_secret: str, issuer:
                          'Otherwise skipp all options to launch interactive login mode')
     if is_client_cred_login and (not client_id or not client_secret):
         raise UsageError('You must pass both client_id and client_secret to client_credentials login')
-    if is_client_cred_login and not config.ISSUER_URL:
+    if is_client_cred_login and not issuer:
         raise UsageError('You must provide --issuer parameter to do client_credentials login. '
                          'Or set ISSUER_URL option in config file')
 
-    # fetch openid configuration
-    if config.ISSUER_URL:
-        fetch_openid_conf(config.ISSUER_URL)
-
     # login
     api_client = api.RemoteAPIClient(api_host, token, client_id, client_secret,
-                                     non_interactive=not is_interactive_login)
+                                     non_interactive=not is_interactive_login,
+                                     issuer_url=issuer)
     try:
         api_client.info()
+        print('Success! Credentials have been saved.')
     except api.IncorrectAuthorizationToken as wrong_token:
         LOG.error('Wrong authorization token\n%s', wrong_token)
         raise
@@ -108,7 +86,17 @@ def login(api_host: str, token: str, client_id: str, client_secret: str, issuer:
                   f'Error: {connection_exc}')
         raise
 
-    print('Success! Credentials have been saved.')
+    # clean config from previous credentials
+    _reset_credentials()
+
+    # update config
+    update_config_file(
+        API_URL=api_host,
+        ODAHUFLOWCTL_OAUTH_CLIENT_ID=client_id,
+        ODAHUFLOWCTL_OAUTH_CLIENT_SECRET=client_secret,
+        API_TOKEN=token,
+        ISSUER_URL=issuer
+    )
 
 
 @click.command()

--- a/packages/cli/odahuflow/cli/parsers/security.py
+++ b/packages/cli/odahuflow/cli/parsers/security.py
@@ -41,7 +41,8 @@ def _reset_credentials():
                        API_ISSUING_URL=None,
                        ODAHUFLOWCTL_OAUTH_CLIENT_ID=None,
                        ODAHUFLOWCTL_OAUTH_CLIENT_SECRET=None,
-                       ISSUER_URL=None)
+                       ISSUER_URL=None,
+                       MODEL_HOST=None)
 
 
 def fetch_openid_conf(issuer: str) -> None:

--- a/packages/cli/odahuflow/cli/parsers/security.py
+++ b/packages/cli/odahuflow/cli/parsers/security.py
@@ -77,6 +77,19 @@ def login(api_host: str, token: str, client_id: str, client_secret: str, issuer:
                                      issuer_url=issuer)
     try:
         api_client.info()
+
+        # clean config from previous credentials
+        _reset_credentials()
+
+        # update config
+        update_config_file(
+            API_URL=api_host,
+            ODAHUFLOWCTL_OAUTH_CLIENT_ID=client_id,
+            ODAHUFLOWCTL_OAUTH_CLIENT_SECRET=client_secret,
+            API_TOKEN=token,
+            ISSUER_URL=issuer
+        )
+
         print('Success! Credentials have been saved.')
     except api.IncorrectAuthorizationToken as wrong_token:
         LOG.error('Wrong authorization token\n%s', wrong_token)
@@ -85,18 +98,6 @@ def login(api_host: str, token: str, client_id: str, client_secret: str, issuer:
         LOG.error(f'Failed to connect to API host!'
                   f'Error: {connection_exc}')
         raise
-
-    # clean config from previous credentials
-    _reset_credentials()
-
-    # update config
-    update_config_file(
-        API_URL=api_host,
-        ODAHUFLOWCTL_OAUTH_CLIENT_ID=client_id,
-        ODAHUFLOWCTL_OAUTH_CLIENT_SECRET=client_secret,
-        API_TOKEN=token,
-        ISSUER_URL=issuer
-    )
 
 
 @click.command()

--- a/packages/cli/odahuflow/cli/parsers/security.py
+++ b/packages/cli/odahuflow/cli/parsers/security.py
@@ -56,6 +56,18 @@ def login(api_host: str, token: str, client_id: str, client_secret: str, issuer:
     Check that credentials is correct and save to the config
     """
 
+    # clean config from previous credentials
+    _reset_credentials()
+
+    # update config
+    update_config_file(
+        API_URL=api_host,
+        API_TOKEN=token,
+        ODAHUFLOWCTL_OAUTH_CLIENT_ID=client_id,
+        ODAHUFLOWCTL_OAUTH_CLIENT_SECRET=client_secret,
+        ISSUER_URL=issuer
+    )
+
     # set predicates
     is_token_login = bool(token)
     is_client_cred_login = bool(client_id) or bool(client_secret)
@@ -77,19 +89,6 @@ def login(api_host: str, token: str, client_id: str, client_secret: str, issuer:
                                      issuer_url=issuer)
     try:
         api_client.info()
-
-        # clean config from previous credentials
-        _reset_credentials()
-
-        # update config
-        update_config_file(
-            API_URL=api_host,
-            API_TOKEN=token,
-            ODAHUFLOWCTL_OAUTH_CLIENT_ID=client_id,
-            ODAHUFLOWCTL_OAUTH_CLIENT_SECRET=client_secret,
-            ISSUER_URL=issuer
-        )
-
         print('Success! Credentials have been saved.')
     except api.IncorrectAuthorizationToken as wrong_token:
         LOG.error('Wrong authorization token\n%s', wrong_token)

--- a/packages/sdk/odahuflow/sdk/clients/api.py
+++ b/packages/sdk/odahuflow/sdk/clients/api.py
@@ -247,7 +247,7 @@ class Authenticator:
         )
         if not login_result:
             raise IncorrectClientCredentials(
-                'Client credentials in not correct. \n'
+                'Client credentials are not correct.\n'
                 'Please login again'
             )
         else:

--- a/packages/sdk/odahuflow/sdk/clients/api.py
+++ b/packages/sdk/odahuflow/sdk/clients/api.py
@@ -176,7 +176,6 @@ class Authenticator:
         self._interactive_login_finished = threading.Event()
         self._token = token
         self._issuer_url = issuer_url
-        self._api_issuing_url = fetch_openid_configuration(self._issuer_url)
 
         # Force if set
         if odahuflow.sdk.config.ODAHUFLOWCTL_NONINTERACTIVE:
@@ -219,7 +218,7 @@ class Authenticator:
         if self._refresh_token_exists:
             LOGGER.debug('Refresh token for %s has been found, trying to use it', odahuflow.sdk.config.API_ISSUING_URL)
             self._login_with_refresh_token()
-        elif self._client_id and self._client_secret and self._api_issuing_url:
+        elif self._client_id and self._client_secret and fetch_openid_configuration(self._issuer_url):
             self._login_with_client_credentials()
         elif self._interactive_mode_enabled:
             # Start interactive flow
@@ -246,7 +245,7 @@ class Authenticator:
 
     def _login_with_client_credentials(self):
         login_result = do_client_cred_authentication(
-            issue_token_url=self._api_issuing_url, client_id=self._client_id,
+            issue_token_url=fetch_openid_configuration(self._issuer_url), client_id=self._client_id,
             client_secret=self._client_secret
         )
         if not login_result:
@@ -455,7 +454,7 @@ class RemoteAPIClient:
         :param action: HTTP method (GET, POST, PUT, DELETE)
         :return: response content
         """
-        response = self._request(url_template, action=action, stream=True, payload=params)
+        response = self._request(url_template, payload=params, action=action, stream=True)
 
         with response:
             if not response.ok:

--- a/packages/sdk/odahuflow/sdk/clients/api.py
+++ b/packages/sdk/odahuflow/sdk/clients/api.py
@@ -140,12 +140,12 @@ class URLBuilder:
         return target_url
 
     def build_request_kwargs(self,
-                              url_template: str,
-                              payload: Mapping[Any, Any] = None,
-                              action: str = 'GET',
-                              stream: bool = False,
-                              token: Optional[str] = None
-                              ) -> Dict[str, Any]:
+                             url_template: str,
+                             payload: Mapping[Any, Any] = None,
+                             action: str = 'GET',
+                             stream: bool = False,
+                             token: Optional[str] = None
+                             ) -> Dict[str, Any]:
         target_url = self.build_url(url_template)
         headers = {}
         if token:
@@ -184,10 +184,11 @@ class Authenticator:
     @staticmethod
     def login_required(response):
         """
-        Check whether the login is required or client is already is authorised
+        Check whether the login is required or a client is already authorised
         :param response:
         :return:
         """
+
         # We assume if there were redirects then credentials are out of date and we can refresh or build auth url
 
         def not_authorized_resp_code():
@@ -214,6 +215,9 @@ class Authenticator:
                 'Please try to log in again'
             )
 
+        # use default value if self._issuer_url is empty
+        self._issuer_url = self._issuer_url or odahuflow.sdk.config.API_ISSUING_URL
+
         LOGGER.debug('Redirect has been detected. Trying to refresh a token')
         if self._refresh_token_exists:
             LOGGER.debug('Refresh token for %s has been found, trying to use it', odahuflow.sdk.config.API_ISSUING_URL)
@@ -225,7 +229,7 @@ class Authenticator:
             self._login_interactive_mode(url)
         else:
             raise IncorrectAuthorizationToken(
-                f'{self._credentials_error_status}. \n'
+                f'{self._credentials_error_status}.\n'
                 'Please provide correct temporary token or disable non interactive mode'
             )
 
@@ -244,6 +248,10 @@ class Authenticator:
             self._update_config_with_new_oauth_config(login_result)
 
     def _login_with_client_credentials(self):
+
+        # use default value if self._issuer_url is empty
+        self._issuer_url = self._issuer_url or odahuflow.sdk.config.API_ISSUING_URL
+
         login_result = do_client_cred_authentication(
             issue_token_url=fetch_openid_configuration(self._issuer_url), client_id=self._client_id,
             client_secret=self._client_secret
@@ -572,7 +580,6 @@ class AsyncRemoteAPIClient:
             chunk = bytes_chunk.decode(encoding)
 
             if pending is not None:
-
                 chunk = pending + chunk
 
             lines = chunk.splitlines()

--- a/packages/sdk/odahuflow/sdk/clients/oauth_handler.py
+++ b/packages/sdk/odahuflow/sdk/clients/oauth_handler.py
@@ -185,7 +185,7 @@ def do_client_cred_authentication(
         issue_token_url: str = config.API_ISSUING_URL
 ):
     """
-    Get access and id token using oauth2 client credentials fow
+    Get access and id token using oauth2 client credentials flow
     :param client_id:
     :param client_secret:
     :param issue_token_url:

--- a/packages/sdk/odahuflow/sdk/clients/oidc.py
+++ b/packages/sdk/odahuflow/sdk/clients/oidc.py
@@ -26,6 +26,20 @@ WELL_KNOWN_CONFIGURATION_URL = '.well-known/openid-configuration'
 TOKEN_ENDPOINT = 'token_endpoint'
 
 
+def fetch_openid_configuration(issuer: str) -> str:
+    """
+    returns token_endpoint (candidate for API_ISSUING_URL variable)
+    from ISSUER_URL variable
+
+    :param issuer: ISSUER_URL config variable
+    :return: token_endpoint
+    """
+    conf = OpenIdProviderConfiguration(issuer)
+    conf.fetch_configuration()
+
+    return conf.token_endpoint
+
+
 class OpenIdProviderConfiguration:
     """
     OpenID Provider Configuration according to https://openid.net/specs/openid-connect-discovery-1_0.html

--- a/packages/sdk/odahuflow/sdk/config.py
+++ b/packages/sdk/odahuflow/sdk/config.py
@@ -339,7 +339,6 @@ DEBUG = ConfigVariableDeclaration('DEBUG', False, cast_bool,
                                   'Enable verbose program output',
                                   True)
 
-
 # Model invocation testing
 MODEL_SERVER_URL = ConfigVariableDeclaration('MODEL_SERVER_URL', '', str, 'Default url of model server', True)
 
@@ -348,7 +347,6 @@ MODEL_HOST = ConfigVariableDeclaration('MODEL_HOST', '', str, 'Default host of m
 MODEL_DEPLOYMENT_NAME = ConfigVariableDeclaration('MODEL_DEPLOYMENT_NAME', '', str, 'Model deployment name', True)
 
 MODEL_ROUTE_NAME = ConfigVariableDeclaration('MODEL_ROUTE_NAME', '', str, 'Model deployment name', True)
-
 
 # API endpoint
 API_URL = ConfigVariableDeclaration('API_URL', 'http://localhost:5000', str,
@@ -368,27 +366,27 @@ ISSUER_URL = ConfigVariableDeclaration('ISSUER_URL', None, str, 'OIDC Issuer URL
 
 # Auth
 ODAHUFLOWCTL_OAUTH_CLIENT_ID = ConfigVariableDeclaration('ODAHUFLOWCTL_OAUTH_CLIENT_ID', 'legion-cli', str,
-                                                      'Set OAuth2 Client id',
-                                                      True)
+                                                         'Set OAuth2 Client id',
+                                                         True)
 
 ODAHUFLOWCTL_OAUTH_CLIENT_SECRET = ConfigVariableDeclaration('ODAHUFLOWCTL_OAUTH_CLIENT_SECRET', '', str,
-                                                          'Set OAuth2 Client id',
-                                                          True)
+                                                             'Set OAuth2 Client id',
+                                                             True)
 
 ODAHUFLOWCTL_OAUTH_SCOPE = ConfigVariableDeclaration('ODAHUFLOWCTL_OAUTH_SCOPE',
-                                                  'openid profile email offline_access groups', str,
-                                                  'Set OAuth2 scope',
-                                                  True)
+                                                     'openid profile email offline_access groups', str,
+                                                     'Set OAuth2 scope',
+                                                     True)
 
 ODAHUFLOWCTL_OAUTH_LOOPBACK_HOST = ConfigVariableDeclaration('ODAHUFLOWCTL_OAUTH_LOOPBACK_HOST',
-                                                          '127.0.0.1', str,
-                                                          'Target redirect for OAuth2 interactive authorization',
-                                                          True)
+                                                             '127.0.0.1', str,
+                                                             'Target redirect for OAuth2 interactive authorization',
+                                                             True)
 
 ODAHUFLOWCTL_OAUTH_LOOPBACK_URL = ConfigVariableDeclaration('ODAHUFLOWCTL_OAUTH_LOOPBACK_URL',
-                                                         '/oauth/callback', str,
-                                                         'Target redirect url for OAuth2 interactive authorization',
-                                                         True)
+                                                            '/oauth/callback', str,
+                                                            'Target redirect url for OAuth2 interactive authorization',
+                                                            True)
 
 ODAHUFLOWCTL_OAUTH_TOKEN_ISSUING_URL = ConfigVariableDeclaration('ODAHUFLOWCTL_OAUTH_TOKEN_ISSUING_URL',
                                                                  '', str,
@@ -407,7 +405,7 @@ JUPYTER_REDIRECT_URL = ConfigVariableDeclaration('JUPYTER_REDIRECT_URL',
                                                  True)
 
 ODAHUFLOWCTL_NONINTERACTIVE = ConfigVariableDeclaration('ODAHUFLOWCTL_NONINTERACTIVE', False,
-                                                     bool, 'Disable any interaction (e.g. authorization)', True)
+                                                        bool, 'Disable any interaction (e.g. authorization)', True)
 
 # Local
 


### PR DESCRIPTION
- added `MODEL_HOST` config variable to reset during logout `def _reset_credentials()`;
- added `_issuer_url` param, so that you could logon through RemoteAPIClient passing client_id, client_secret, and issuer and not  setting issuer through `config.ISSUER_URL`