### PR TITLE
[#348] Validate fields that used as K8s labels

### DIFF
--- a/packages/operator/pkg/apiserver/routes/v1/deployment/model_deployment_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/deployment/model_deployment_validation.go
@@ -75,6 +75,8 @@ func (mdv *ModelDeploymentValidator) ValidatesMDAndSetDefaults(md *deployment.Mo
 			"Deployment name", md.ID, "role name", MdDefaultMinimumReplicas)
 		defaultRoleName := mdv.modelDeploymentConfig.Security.RoleName
 		md.Spec.RoleName = &defaultRoleName
+	} else {
+		err = multierr.Append(err, validation.ValidateK8sLabel(*md.Spec.RoleName))
 	}
 
 	if md.Spec.MinReplicas == nil {

--- a/packages/operator/pkg/apiserver/routes/v1/deployment/model_deployment_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/deployment/model_deployment_validation_test.go
@@ -308,3 +308,13 @@ func (s *ModelDeploymentValidationSuite) TestValidateNodeSelector_Invalid() {
 	s.Assertions.NotNil(err)
 	s.Assertions.Len(multierr.Errors(err), 1)
 }
+
+// Deployment has Role Name that is not valid K8s label; expect a validation error
+func (s *ModelDeploymentValidationSuite) TestValidateRoleName_Invalid() {
+	mt := validDeployment
+	invalidLabel := "invalid label!"
+	mt.Spec.RoleName = &invalidLabel
+	err := s.defaultModelValidator.ValidatesMDAndSetDefaults(&mt)
+	s.Assertions.Error(err)
+	s.Assertions.Contains(err.Error(), invalidLabel)
+}

--- a/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation_test.go
@@ -39,6 +39,7 @@ import (
 const (
 	gpuResourceName     = "nvidia"
 	mtvOutputConnection = "training-validation-output-connection"
+	invalidK8sLabel     = "invalid label!"
 )
 
 var (
@@ -317,7 +318,7 @@ func (s *ModelTrainingValidationSuite) TestMtToolchainEmptyName() {
 
 func (s *ModelTrainingValidationSuite) TestMtToolchain_invalid() {
 	mt := validTraining
-	mt.Spec.Toolchain = "invalid label!"
+	mt.Spec.Toolchain = invalidK8sLabel
 
 	err := s.validator.ValidatesAndSetDefaults(&mt)
 	s.Assertions.Error(err)
@@ -336,7 +337,7 @@ func (s *ModelTrainingValidationSuite) TestMtEmptyModelName() {
 
 func (s *ModelTrainingValidationSuite) TestMtName_invalid() {
 	mt := validTraining
-	mt.Spec.Model.Name = "invalid label!"
+	mt.Spec.Model.Name = invalidK8sLabel
 
 	err := s.validator.ValidatesAndSetDefaults(&mt)
 	s.Assertions.Error(err)
@@ -355,7 +356,7 @@ func (s *ModelTrainingValidationSuite) TestMtEmptyModelVersion() {
 
 func (s *ModelTrainingValidationSuite) TestMtVersion_invalid() {
 	mt := validTraining
-	mt.Spec.Model.Version = "invalid label!"
+	mt.Spec.Model.Version = invalidK8sLabel
 
 	err := s.validator.ValidatesAndSetDefaults(&mt)
 	s.Assertions.Error(err)

--- a/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation_test.go
@@ -315,6 +315,15 @@ func (s *ModelTrainingValidationSuite) TestMtToolchainEmptyName() {
 	s.g.Expect(err.Error()).To(ContainSubstring(train_route.ToolchainEmptyErrorMessage))
 }
 
+func (s *ModelTrainingValidationSuite) TestMtToolchain_invalid() {
+	mt := validTraining
+	mt.Spec.Toolchain = "invalid label!"
+
+	err := s.validator.ValidatesAndSetDefaults(&mt)
+	s.Assertions.Error(err)
+	s.Assertions.Contains(err.Error(), mt.Spec.Toolchain)
+}
+
 func (s *ModelTrainingValidationSuite) TestMtEmptyModelName() {
 	mt := &training.ModelTraining{
 		Spec: v1alpha1.ModelTrainingSpec{},
@@ -325,6 +334,15 @@ func (s *ModelTrainingValidationSuite) TestMtEmptyModelName() {
 	s.g.Expect(err.Error()).To(ContainSubstring(train_route.EmptyModelNameErrorMessage))
 }
 
+func (s *ModelTrainingValidationSuite) TestMtName_invalid() {
+	mt := validTraining
+	mt.Spec.Model.Name = "invalid label!"
+
+	err := s.validator.ValidatesAndSetDefaults(&mt)
+	s.Assertions.Error(err)
+	s.Assertions.Contains(err.Error(), mt.Spec.Model.Name)
+}
+
 func (s *ModelTrainingValidationSuite) TestMtEmptyModelVersion() {
 	mt := &training.ModelTraining{
 		Spec: v1alpha1.ModelTrainingSpec{},
@@ -333,6 +351,15 @@ func (s *ModelTrainingValidationSuite) TestMtEmptyModelVersion() {
 	err := s.validator.ValidatesAndSetDefaults(mt)
 	s.g.Expect(err).To(HaveOccurred())
 	s.g.Expect(err.Error()).To(ContainSubstring(train_route.EmptyModelVersionErrorMessage))
+}
+
+func (s *ModelTrainingValidationSuite) TestMtVersion_invalid() {
+	mt := validTraining
+	mt.Spec.Model.Version = "invalid label!"
+
+	err := s.validator.ValidatesAndSetDefaults(&mt)
+	s.Assertions.Error(err)
+	s.Assertions.Contains(err.Error(), mt.Spec.Model.Version)
 }
 
 func (s *ModelTrainingValidationSuite) TestMtGenerationOutputArtifactName() {

--- a/packages/operator/pkg/validation/validation.go
+++ b/packages/operator/pkg/validation/validation.go
@@ -59,3 +59,14 @@ func ValidateID(id string) error {
 
 	return ErrIDValidation
 }
+
+// K8s label must start/end with alphanumeric character, can consist of
+var k8sLabelRegex = regexp.MustCompile("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")
+var LabelValueValidationErrorTemplate = "%s must be valid Kubernetes label, i.e. match this pattern: %s"
+
+func ValidateK8sLabel(label string) error {
+	if k8sLabelRegex.MatchString(label) {
+		return nil
+	}
+	return errors.New(fmt.Sprintf(LabelValueValidationErrorTemplate, label, k8sLabelRegex))
+}

--- a/packages/operator/pkg/validation/validation.go
+++ b/packages/operator/pkg/validation/validation.go
@@ -68,5 +68,5 @@ func ValidateK8sLabel(label string) error {
 	if k8sLabelRegex.MatchString(label) {
 		return nil
 	}
-	return errors.New(fmt.Sprintf(LabelValueValidationErrorTemplate, label, k8sLabelRegex))
+	return fmt.Errorf(LabelValueValidationErrorTemplate, label, k8sLabelRegex)
 }


### PR DESCRIPTION
Fixes #348.
We use some fields as label values. We have to make sure that they are in the format that K8s expects. Otherwise a resource creation fails.