### PR TITLE
[#158] Minor cli messages

### DIFF
--- a/packages/cli/odahuflow/cli/parsers/local/packaging.py
+++ b/packages/cli/odahuflow/cli/parsers/local/packaging.py
@@ -97,7 +97,7 @@ def run(client: ModelPackagingClient, pack_id: str, manifest_file: List[str], ma
             mp = entity
 
     if not mp:
-        LOGGER.debug(
+        click.echo(
             f'The {pack_id} packaging not found in the manifest files.'
             f' Trying to retrieve it from API server'
         )
@@ -106,7 +106,7 @@ def run(client: ModelPackagingClient, pack_id: str, manifest_file: List[str], ma
     integration_name = mp.spec.integration_name
     packager = packagers.get(integration_name)
     if not packager:
-        LOGGER.debug(
+        click.echo(
             f'The {integration_name} packager not found in the manifest files.'
             f' Trying to retrieve it from API server'
         )
@@ -114,8 +114,7 @@ def run(client: ModelPackagingClient, pack_id: str, manifest_file: List[str], ma
 
     if artifact_name:
         mp.spec.artifact_name = artifact_name
-
-        LOGGER.debug('Override the artifact namesdsdsdsdsdsdsd')
+        LOGGER.debug('Override the artifact name')
 
     if is_target_disabled:
         mp.spec.targets = []

--- a/packages/cli/odahuflow/cli/parsers/local/training.py
+++ b/packages/cli/odahuflow/cli/parsers/local/training.py
@@ -142,12 +142,12 @@ def run(client: ModelTrainingClient, train_id: str, manifest_file: List[str], ma
             mt = entity
 
     if not mt:
-        LOGGER.debug(f'{train_id} training not found. Trying to retrieve it from API server')
+        click.echo(f'{train_id} training not found. Trying to retrieve it from API server')
         mt = client.get(train_id)
 
     toolchain = toolchains.get(mt.spec.toolchain)
     if not toolchain:
-        LOGGER.debug(f'{toolchain} toolchain not found. Trying to retrieve it from API server')
+        click.echo(f'{toolchain} toolchain not found. Trying to retrieve it from API server')
         toolchain = ToolchainIntegrationClient.construct_from_other(client).get(mt.spec.toolchain)
 
     trainer = K8sTrainer(


### PR DESCRIPTION
Closes #158 
From issue comments:

> We found out that the behavior it expected: parse files passed as CLI arguments. If ModelTraining or ToolchainIntegration are not found there, it tries to pull them from API. It user is not logged it, well, it is expected that we cannot proceed until they fix it. 
> 
> Also, currently if training/toolchain are fetched from API server, an appropriate message shows up in --verbose mode only. After discussion with @BPylypenko (reporter) we decided that CLI should print the message anyway, with or without verbose.