### PR TITLE
[#307] Mask client secret in CLI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ services:
 install: skip
 branches:
   only:
-  - master
-  - develop
+  - /.*/
 
 matrix:
   include:

--- a/packages/cli/odahuflow/cli/parsers/config.py
+++ b/packages/cli/odahuflow/cli/parsers/config.py
@@ -135,7 +135,7 @@ def _print_variable_information(name: str, show_secrets: bool = False):
     """
     description = config.ALL_VARIABLES[name]
     current_value = getattr(config, name)
-    is_secret = any(sub in name for sub in ('_PASSWORD', '_TOKEN'))
+    is_secret = any(sub in name for sub in ('_PASSWORD', '_TOKEN', '_SECRET'))
     click.echo('{} - {}\n  default: {!r}'.format(name, description.description, description.default))
     if current_value != description.default:
         if is_secret and not show_secrets:

--- a/packages/operator/pkg/rclone/azureblob.go
+++ b/packages/operator/pkg/rclone/azureblob.go
@@ -28,10 +28,6 @@ import (
 	"strings"
 )
 
-const (
-	httpsSchema = "https://"
-	wasbSchema  = "wasb://"
-)
 
 func createAzureBlobConfig(configName string, conn *v1alpha1.ConnectionSpec) (*FileDescription, error) {
 	_, err := fs.Find("azureblob")
@@ -53,9 +49,7 @@ func createAzureBlobConfig(configName string, conn *v1alpha1.ConnectionSpec) (*F
 	}
 
 	uriPath := parsedURI.Path
-	if strings.HasPrefix(uriPath, "/") {
-		uriPath = uriPath[1:]
-	}
+	uriPath= strings.TrimPrefix(uriPath, "/")
 
 	pathParts := strings.Split(uriPath, "/")
 	if len(pathParts) == 0 {


### PR DESCRIPTION
Fix #307 
Mask `ODAHUFLOWCTL_OAUTH_CLIENT_SECRET` (and other properties ending with `_SECRET` as well) in output of `odahuflowctl config all`.

Before:
```
ODAHUFLOWCTL_OAUTH_CLIENT_SECRET - Set OAuth2 Client id
  default: ''
  current: 'abc'
```

After:
```
ODAHUFLOWCTL_OAUTH_CLIENT_SECRET - Set OAuth2 Client id
  default: ''
  current: '****'
```