### PR TITLE
fix for not supported shells, completion will give human friendly error

### DIFF
--- a/packages/cli/odahuflow/cli/parsers/completion.py
+++ b/packages/cli/odahuflow/cli/parsers/completion.py
@@ -28,4 +28,9 @@ def completion(shell):
         source <(odahuflowctl completion zsh)
     \f
     """
-    click.echo(click_completion.core.get_code(shell))
+    shell = shell or click_completion.lib.get_auto_shell()
+
+    if shell in click_completion.core.shells:
+        click.echo(click_completion.core.get_code(shell))
+    else:
+        raise click.ClickException(f'"{shell}" shell is not supported.')


### PR DESCRIPTION
before:
```
Error: 'cmd'
For more information rerun command with --verbose flag
```
after
`Error: "cmd" shell is not supported.`