### PR TITLE
[#375] Minor fix in CLI gppi group documentation

### DIFF
--- a/packages/cli/odahuflow/cli/parsers/gppi.py
+++ b/packages/cli/odahuflow/cli/parsers/gppi.py
@@ -17,6 +17,7 @@ import os
 import sys
 
 import click
+
 from odahuflow.sdk.gppi.executor import GPPITrainedModelBinary
 
 ODAHUFLOW_GPPI_MODEL_PATH_ENV_NAME = 'ODAHUFLOW_GPPI_MODEL_PATH'
@@ -55,11 +56,11 @@ def gppi(ctx, gppi_model_path: str, use_current_env: bool = False, env_name: str
 @click.pass_context
 def test(ctx):
     """
-    Initialize GPPI model and try to execute api
+    Initialize GPPI model and try to execute api.
 
     Next API are tested:
 
-    Executes .info() method
+    Executes .info() method;
 
     Executes .predict_on_matrix() method
     with data deserialized from head_input.pkl as a parameter
@@ -77,6 +78,8 @@ def test(ctx):
 @click.pass_context
 def predict(ctx, input_file: str, output_dir: str, output_file_name: str):
     """
+    Invokes a prediction on a trained model.
+    \f
 
     :param ctx:
     :param input_file: Input JSON file for predictions


### PR DESCRIPTION
Fixes #375 
Before:
```
Commands:
  predict  :param ctx: :param input_file: Input JSON file for predictions :param output_dir:...
  test     Initialize GPPI model and try to execute api Next API are tested: Executes .info()...
```
After:
```
Commands:
  predict  Invokes a prediction on a trained model.
  test     Initialize GPPI model and try to execute api.
```