### PR TITLE
[#148] Use default VCS branch if none provided in training/connection

### DIFF
--- a/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation.go
@@ -33,14 +33,12 @@ import (
 )
 
 const (
-	MtVcsNotExistsErrorMessage    = "cannot find VCS Connection"
-	EmptyModelNameErrorMessage    = "model name must be non-empty"
-	EmptyModelVersionErrorMessage = "model version must be non-empty"
-	EmptyVcsNameMessageError      = "VCS name is empty"
-	ValidationMtErrorMessage      = "Validation of model training is failed"
-	WrongVcsTypeErrorMessage      = "VCS connection must have the GIT type. You pass the connection of %s type"
-	WrongVcsReferenceErrorMessage = "you should specify a VCS reference for model training explicitly." +
-		" Because %s does not have default reference"
+	MtVcsNotExistsErrorMessage       = "cannot find VCS Connection"
+	EmptyModelNameErrorMessage       = "model name must be non-empty"
+	EmptyModelVersionErrorMessage    = "model version must be non-empty"
+	EmptyVcsNameMessageError         = "VCS name is empty"
+	ValidationMtErrorMessage         = "Validation of model training is failed"
+	WrongVcsTypeErrorMessage         = "VCS connection must have the GIT type. You pass the connection of %s type"
 	EmptyDataBindingNameErrorMessage = "you should specify connection name for %d number of data binding"
 	EmptyDataBindingPathErrorMessage = "you should specify local path for %d number of data binding"
 	WrongDataBindingTypeErrorMessage = "%s data binding has wrong data type. Currently supported the following types" +
@@ -202,6 +200,8 @@ func (mtv *MtValidator) validateVCS(mt *training.ModelTraining) (err error) {
 			logMT.Info("VCS reference parameter is nil. Set the default value",
 				"name", mt.ID, "reference", vcs.Spec.Reference)
 			mt.Spec.Reference = vcs.Spec.Reference
+		default:
+			logMT.Info("Neither VCS connection or Training has reference specified, using default")
 		}
 	}
 

--- a/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation.go
@@ -197,11 +197,11 @@ func (mtv *MtValidator) validateVCS(mt *training.ModelTraining) (err error) {
 		case vcs.Spec.Type != connection.GITType:
 			err = multierr.Append(err, fmt.Errorf(WrongVcsTypeErrorMessage, vcs.Spec.Type))
 		case len(vcs.Spec.Reference) != 0:
-			logMT.Info("VCS reference parameter is nil. Set the default value",
+			logMT.Info("VCS reference parameter is nil. Take the value from connection specification",
 				"name", mt.ID, "reference", vcs.Spec.Reference)
 			mt.Spec.Reference = vcs.Spec.Reference
 		default:
-			logMT.Info("Neither VCS connection or Training has reference specified, using default")
+			logMT.Info("Neither VCS connection or Training has reference specified, using VCS default branch")
 		}
 	}
 

--- a/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation.go
@@ -198,9 +198,7 @@ func (mtv *MtValidator) validateVCS(mt *training.ModelTraining) (err error) {
 		switch {
 		case vcs.Spec.Type != connection.GITType:
 			err = multierr.Append(err, fmt.Errorf(WrongVcsTypeErrorMessage, vcs.Spec.Type))
-		case len(vcs.Spec.Reference) == 0:
-			err = multierr.Append(err, fmt.Errorf(WrongVcsReferenceErrorMessage, vcs.ID))
-		default:
+		case len(vcs.Spec.Reference) != 0:
 			logMT.Info("VCS reference parameter is nil. Set the default value",
 				"name", mt.ID, "reference", vcs.Spec.Reference)
 			mt.Spec.Reference = vcs.Spec.Reference

--- a/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation_test.go
@@ -221,16 +221,11 @@ func (s *ModelTrainingValidationSuite) TestMtNotExplicitMTReference() {
 	s.g.Expect(err).Should(BeNil())
 	defer s.connRepository.DeleteConnection(conn.ID)
 
-	mt := &training.ModelTraining{
-		Spec: v1alpha1.ModelTrainingSpec{
-			VCSName:   conn.ID,
-			Reference: "",
-		},
-	}
+	mt := validTraining
+	mt.Spec.Reference = ""
 
-	err = s.validator.ValidatesAndSetDefaults(mt)
-	s.g.Expect(err).ShouldNot(BeNil())
-	s.g.Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(train_route.WrongVcsReferenceErrorMessage, conn.ID)))
+	err = s.validator.ValidatesAndSetDefaults(&mt)
+	s.Assertions.NoError(err)
 }
 
 func (s *ModelTrainingValidationSuite) TestMtEmptyVcsName() {


### PR DESCRIPTION
Closes #148 
Made `reference` field optional for `Training`.
Before `reference` was optional for `Training` if only `VCS connection` does have default `reference`. Now it is optional anyway. If `reference` was not specified in neither `VCS connection` or `training` then default HEAD after cloning the repo is used.