### PR TITLE
fixes for local packaging

### DIFF
--- a/packages/cli/odahuflow/cli/parsers/local/packaging.py
+++ b/packages/cli/odahuflow/cli/parsers/local/packaging.py
@@ -16,6 +16,7 @@
 """
 Local packaging commands for odahuflow cli
 """
+import os
 import logging
 from typing import List, Dict, Optional
 
@@ -126,6 +127,8 @@ def run(client: ModelPackagingClient, pack_id: str, manifest_file: List[str], ma
         packaging_integration=packager,
         targets=[],
     )
+    
+    artifact_path = os.path.join(artifact_path, artifact_name)
 
     result = start_package(k8s_packager, artifact_path)
 

--- a/packages/cli/odahuflow/cli/parsers/local/packaging.py
+++ b/packages/cli/odahuflow/cli/parsers/local/packaging.py
@@ -16,7 +16,6 @@
 """
 Local packaging commands for odahuflow cli
 """
-import os
 import logging
 from typing import List, Dict, Optional
 
@@ -127,8 +126,6 @@ def run(client: ModelPackagingClient, pack_id: str, manifest_file: List[str], ma
         packaging_integration=packager,
         targets=[],
     )
-    
-    artifact_path = os.path.join(artifact_path, artifact_name)
 
     result = start_package(k8s_packager, artifact_path)
 

--- a/packages/cli/odahuflow/cli/parsers/local/packaging.py
+++ b/packages/cli/odahuflow/cli/parsers/local/packaging.py
@@ -63,7 +63,7 @@ def cleanup_containers():
 @packaging_group.command()
 @click.option('--pack-id', '--id', help='Model packaging ID', required=True)
 @click.option('--manifest-file', '-f', type=click.Path(), multiple=True,
-              help='Path to a ODAHU-flow manifest file')
+              help='Path to an ODAHU-flow manifest file')
 @click.option('--manifest-dir', '-d', type=click.Path(), multiple=True,
               help='Path to a directory with ODAHU-flow manifest files')
 @click.option('--artifact-path', type=click.Path(),

--- a/packages/cli/odahuflow/cli/parsers/local/training.py
+++ b/packages/cli/odahuflow/cli/parsers/local/training.py
@@ -110,7 +110,7 @@ def cleanup_containers():
 @training_group.command()
 @click.option('--train-id', '--id', help='Model training ID', required=True)
 @click.option('--manifest-file', '-f', type=click.Path(), multiple=True,
-              help='Path to a ODAHU-flow manifest file')
+              help='Path to an ODAHU-flow manifest file')
 @click.option('--manifest-dir', '-d', type=click.Path(), multiple=True,
               help='Path to a directory with ODAHU-flow manifest files')
 @click.option('--output-dir', '--output', type=click.Path(),

--- a/packages/cli/odahuflow/cli/parsers/local/training.py
+++ b/packages/cli/odahuflow/cli/parsers/local/training.py
@@ -147,7 +147,7 @@ def run(client: ModelTrainingClient, train_id: str, manifest_file: List[str], ma
         click.echo(f'{train_id} training not found. Trying to retrieve it from API server')
         mt = client.get(train_id)
 
-    toolchain = toolchains.get(mt.spec.toolchain) or ""
+    toolchain = toolchains.get(mt.spec.toolchain)
     if not toolchain:
         click.echo(f'{toolchain} toolchain not found. Trying to retrieve it from API server')
         toolchain = ToolchainIntegrationClient.construct_from_other(client).get(mt.spec.toolchain)

--- a/packages/cli/odahuflow/cli/parsers/local/training.py
+++ b/packages/cli/odahuflow/cli/parsers/local/training.py
@@ -147,7 +147,7 @@ def run(client: ModelTrainingClient, train_id: str, manifest_file: List[str], ma
         click.echo(f'{train_id} training not found. Trying to retrieve it from API server')
         mt = client.get(train_id)
 
-    toolchain = toolchains.get(mt.spec.toolchain)
+    toolchain = toolchains.get(mt.spec.toolchain) or ""
     if not toolchain:
         click.echo(f'{toolchain} toolchain not found. Trying to retrieve it from API server')
         toolchain = ToolchainIntegrationClient.construct_from_other(client).get(mt.spec.toolchain)

--- a/packages/cli/odahuflow/cli/parsers/training.py
+++ b/packages/cli/odahuflow/cli/parsers/training.py
@@ -97,8 +97,6 @@ def get(client: ModelTrainingClient, train_id: str, output_format: str):
               help='no wait until scale will be finished')
 @click.option('--timeout', default=DEFAULT_TRAINING_TIMEOUT, type=int,
               help='timeout in seconds. for wait (if no-wait is off)')
-@click.option('--timeout', default=DEFAULT_TRAINING_TIMEOUT, type=int,
-              help='timeout in seconds. for wait (if no-wait is off)')
 @click.option('--ignore-if-exists', is_flag=True,
               help='Ignore if entity is already exists on API server. Return success status code')
 @pass_obj

--- a/packages/operator/pkg/apiserver/routes/v1/deployment/model_deployment_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/deployment/model_deployment_validation.go
@@ -73,7 +73,7 @@ func (mdv *ModelDeploymentValidator) ValidatesMDAndSetDefaults(md *deployment.Mo
 
 	if md.Spec.RoleName == nil || len(*md.Spec.RoleName) == 0 {
 		defaultRoleName := DefaultRolePrefix + md.ID
-		logMD.Info("Role name parameter is nil or empty. Set the model ID as model Role with prefix",
+		logMD.Info("Role name parameter is nil or empty. Set the model Role as the model ID with a prefix",
 			"Deployment name", md.ID, "role name", defaultRoleName)
 		md.Spec.RoleName = &defaultRoleName
 	} else {

--- a/packages/sdk/odahuflow/sdk/clients/api_aggregated.py
+++ b/packages/sdk/odahuflow/sdk/clients/api_aggregated.py
@@ -267,7 +267,7 @@ def parse_resources_file_with_one_item(path: str) -> OdahuflowCloudResourceUpdat
     """
     resources = parse_resources_file(path)
     if len(resources.changes) != 1:
-        raise Exception('{!r} should contain 1 item, but {!r} founded'.format(path, len(resources)))
+        raise Exception('{!r} should contain 1 item, but {!r} found'.format(path, len(resources)))
     return resources.changes[0]
 
 

--- a/packages/sdk/odahuflow/sdk/local/packaging.py
+++ b/packages/sdk/odahuflow/sdk/local/packaging.py
@@ -34,10 +34,12 @@ def read_mp_result_file(config_dir: str) -> Dict[str, Any]:
 
 def start_package(packager: K8sPackager, artifact_path: str) -> Dict[str, Any]:
     if not artifact_path:
-        artifact_path = join(
-            config.LOCAL_MODEL_OUTPUT_DIR,
-            packager.model_packaging.spec.artifact_name
-        )
+        artifact_path = config.LOCAL_MODEL_OUTPUT_DIR
+
+    artifact_path = join(
+        artifact_path,
+        packager.model_packaging.spec.artifact_name
+    )
 
     create_mp_config_file(artifact_path, packager)
 

--- a/packages/sdk/odahuflow/sdk/local/packaging.py
+++ b/packages/sdk/odahuflow/sdk/local/packaging.py
@@ -36,11 +36,12 @@ def start_package(packager: K8sPackager, artifact_path: str) -> Dict[str, Any]:
     if not artifact_path:
         artifact_path = config.LOCAL_MODEL_OUTPUT_DIR
 
-    # Removing .zip extension if there's one
+    # removing .zip extension if there's one
     artifact_name = packager.model_packaging.spec.artifact_name.strip()
     if artifact_name.endswith('.zip'):
         packager.model_packaging.spec.artifact_name = artifact_name[:-4]
 
+    # make full artifact path with artifact name
     artifact_path = join(
         artifact_path,
         packager.model_packaging.spec.artifact_name

--- a/packages/sdk/odahuflow/sdk/local/packaging.py
+++ b/packages/sdk/odahuflow/sdk/local/packaging.py
@@ -36,6 +36,11 @@ def start_package(packager: K8sPackager, artifact_path: str) -> Dict[str, Any]:
     if not artifact_path:
         artifact_path = config.LOCAL_MODEL_OUTPUT_DIR
 
+    # Removing .zip extension if there's one
+    artifact_name = packager.model_packaging.spec.artifact_name.strip()
+    if artifact_name.endswith('.zip'):
+        packager.model_packaging.spec.artifact_name = artifact_name[:-4]
+
     artifact_path = join(
         artifact_path,
         packager.model_packaging.spec.artifact_name

--- a/packages/sdk/tests/local/test_local_packaging.py
+++ b/packages/sdk/tests/local/test_local_packaging.py
@@ -13,6 +13,8 @@
 #  limitations under the License.
 import os
 import json
+from unittest.mock import patch
+
 import docker
 
 import pytest
@@ -22,7 +24,6 @@ from odahuflow.sdk.local import packaging
 from odahuflow.sdk.local.packaging import start_package
 from odahuflow.sdk.models import K8sPackager, ModelPackaging, ModelPackagingSpec, PackagingIntegration, \
     PackagingIntegrationSpec
-
 
 # Format: ['artifact_name', 'artifact_path',
 #          'expected_artifact_name', expected_artifact_path]
@@ -55,6 +56,7 @@ def test_start_package__artifact_name_artifact_path(artifact_name, artifact_path
         # mocking packaging_integration default_image
         packaging_integration=PackagingIntegration(spec=PackagingIntegrationSpec(default_image='default_image')))
 
+    # os_path_join_mock = mocker.patch.object(os.path, 'join')
     create_mp_config_file_mock = mocker.patch.object(packaging, 'create_mp_config_file')
     config_mock = mocker.patch.object(packaging, 'config')
 
@@ -70,8 +72,12 @@ def test_start_package__artifact_name_artifact_path(artifact_name, artifact_path
     start_package(packager, artifact_path)
 
     expected_packager = K8sPackager(
-        model_packaging=ModelPackaging(spec=ModelPackagingSpec(artifact_name=expected_artifact_name)))
-    expected_artifact_path = os.path.join(expected_artifact_path, expected_artifact_name)
+        model_packaging=ModelPackaging(spec=ModelPackagingSpec(artifact_name=expected_artifact_name)),
+        # mocking packaging_integration default_image
+        packaging_integration=PackagingIntegration(spec=PackagingIntegrationSpec(default_image='default_image')))
 
-    create_mp_config_file_mock.assert_called_with(expected_artifact_path, expected_packager)
-    read_mp_result_file_mock.assert_called_with(expected_artifact_path)
+    expected_full_artifact_path = os.path.join(expected_artifact_path, expected_artifact_name)
+
+    # os_path_join_mock.assert_called_with(expected_artifact_path, expected_artifact_name)
+    create_mp_config_file_mock.assert_called_with(expected_full_artifact_path, expected_packager)
+    read_mp_result_file_mock.assert_called_with(expected_full_artifact_path)

--- a/packages/sdk/tests/local/test_local_packaging.py
+++ b/packages/sdk/tests/local/test_local_packaging.py
@@ -54,7 +54,6 @@ def test_start_package__artifact_name_artifact_path(artifact_name, artifact_path
         # mocking packaging_integration default_image
         packaging_integration=PackagingIntegration(spec=PackagingIntegrationSpec(default_image='default_image')))
 
-    # os_path_join_mock = mocker.patch.object(os.path, 'join')
     create_mp_config_file_mock = mocker.patch.object(packaging, 'create_mp_config_file')
     config_mock = mocker.patch.object(packaging, 'config')
 
@@ -76,6 +75,5 @@ def test_start_package__artifact_name_artifact_path(artifact_name, artifact_path
 
     expected_full_artifact_path = os.path.join(expected_artifact_path, expected_artifact_name)
 
-    # os_path_join_mock.assert_called_with(expected_artifact_path, expected_artifact_name)
     create_mp_config_file_mock.assert_called_with(expected_full_artifact_path, expected_packager)
     read_mp_result_file_mock.assert_called_with(expected_full_artifact_path)

--- a/packages/sdk/tests/local/test_local_packaging.py
+++ b/packages/sdk/tests/local/test_local_packaging.py
@@ -1,0 +1,77 @@
+#  Copyright 2020 EPAM Systems
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import json
+import docker
+
+import pytest
+from pytest_mock import MockFixture
+
+from odahuflow.sdk.local import packaging
+from odahuflow.sdk.local.packaging import start_package
+from odahuflow.sdk.models import K8sPackager, ModelPackaging, ModelPackagingSpec, PackagingIntegration, \
+    PackagingIntegrationSpec
+
+
+# Format: ['artifact_name', 'artifact_path',
+#          'expected_artifact_name', expected_artifact_path]
+test_data = [
+    (
+        'wine-1.0', '/odahu/training',
+        'wine-1.0', '/odahu/training'
+    ),
+    (
+        'wine-1.0.zip', '/odahu/training',
+        'wine-1.0', '/odahu/training'
+    ),
+    (
+        'wine-1.0.zip.zip', None,
+        'wine-1.0.zip', '/odahu/default_output'
+    )
+]
+
+DEFAULT_OUTPUT_DIR = '/odahu/default_output'
+
+
+@pytest.mark.parametrize(['artifact_name', 'artifact_path',
+                          'expected_artifact_name', 'expected_artifact_path'],
+                         test_data)
+def test_start_package__artifact_name_artifact_path(artifact_name, artifact_path,
+                                                    expected_artifact_name, expected_artifact_path,
+                                                    mocker: MockFixture):
+    packager = K8sPackager(
+        model_packaging=ModelPackaging(spec=ModelPackagingSpec(artifact_name=artifact_name)),
+        # mocking packaging_integration default_image
+        packaging_integration=PackagingIntegration(spec=PackagingIntegrationSpec(default_image='default_image')))
+
+    create_mp_config_file_mock = mocker.patch.object(packaging, 'create_mp_config_file')
+    config_mock = mocker.patch.object(packaging, 'config')
+
+    mocker.patch.object(docker, 'from_env')
+    mocker.patch.object(json, 'dumps')
+
+    mocker.patch.object(packaging, 'stream_container_logs')
+    mocker.patch.object(packaging, 'raise_error_if_container_failed')
+    read_mp_result_file_mock = mocker.patch.object(packaging, 'read_mp_result_file')
+
+    config_mock.LOCAL_MODEL_OUTPUT_DIR = DEFAULT_OUTPUT_DIR
+
+    start_package(packager, artifact_path)
+
+    expected_packager = K8sPackager(
+        model_packaging=ModelPackaging(spec=ModelPackagingSpec(artifact_name=expected_artifact_name)))
+    expected_artifact_path = os.path.join(expected_artifact_path, expected_artifact_name)
+
+    create_mp_config_file_mock.assert_called_with(expected_artifact_path, expected_packager)
+    read_mp_result_file_mock.assert_called_with(expected_artifact_path)

--- a/packages/sdk/tests/local/test_local_packaging.py
+++ b/packages/sdk/tests/local/test_local_packaging.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 import os
 import json
-from unittest.mock import patch
-
 import docker
 
 import pytest


### PR DESCRIPTION
- when you pass --artifact-path option for local packaging, you shouldn't pass the artifact-name value in it.
for example,
**before** `--artifact-path /my_training/wine-1.0-d1d27bb7-501d-4ae1-b158-beb09c720719`,
**after** `--artifact-path /my_training`

- when you specify in the artifact name of the local packaging `.zip` extension, the `.zip` part would be removed.