### PR TITLE
Fix/packager targets

### DIFF
--- a/packages/cli/Pipfile
+++ b/packages/cli/Pipfile
@@ -16,6 +16,7 @@ click-completion = ">=0.5.2"
 pytest = ">=5.1.2"
 pytest-mock = ">=1.10.4"
 pytest-cov = ">=2.7.1"
+dataclasses = ">=0.7"
 
 [requires]
 python_version = "3.6"

--- a/packages/cli/odahuflow/cli/parsers/local/packaging.py
+++ b/packages/cli/odahuflow/cli/parsers/local/packaging.py
@@ -16,8 +16,9 @@
 """
 Local packaging commands for odahuflow cli
 """
+import base64
 import logging
-from typing import List, Dict, Optional
+from typing import List, Dict, NoReturn, Optional, Tuple
 
 import click
 
@@ -27,10 +28,11 @@ from odahuflow.sdk import config
 from odahuflow.sdk.clients.api_aggregated import \
     parse_resources_file, \
     parse_resources_dir, OdahuflowCloudResourceUpdatePair
+from odahuflow.sdk.clients.connection import ConnectionClient
 from odahuflow.sdk.clients.packaging import ModelPackagingClient
 from odahuflow.sdk.clients.packaging_integration import PackagingIntegrationClient
 from odahuflow.sdk.local.packaging import start_package, cleanup_packaging_docker_containers
-from odahuflow.sdk.models import K8sPackager, ModelPackaging, PackagingIntegration
+from odahuflow.sdk.models import Connection, K8sPackager, ModelPackaging, PackagerTarget, PackagingIntegration, Target
 
 LOGGER = logging.getLogger(__name__)
 
@@ -60,6 +62,136 @@ def cleanup_containers():
     cleanup_packaging_docker_containers()
 
 
+def fetch_local_entities(manifest_file, manifest_dir):
+    """
+    Collect entities from manifest files in local FS and return a result
+    Manifests can be collected from file or files inside a directory
+    Manifests from different sources are combined together
+    :param manifest_file: manifest file
+    :param manifest_dir: directory with manifest files
+    :return:
+    """
+
+    entities: List[OdahuflowCloudResourceUpdatePair] = []
+    for file_path in manifest_file:
+        entities.extend(parse_resources_file(file_path).changes)
+
+    for dir_path in manifest_dir:
+        entities.extend(parse_resources_dir(dir_path))
+
+    return entities
+
+
+def parse_entities(
+        entities: List[OdahuflowCloudResourceUpdatePair], pack_id: str
+) -> (ModelPackaging, Dict[str, PackagingIntegration], Dict[str, Connection]):
+    mp: Optional[ModelPackaging] = None
+
+    packagers: Dict[str, PackagingIntegration] = {}
+    connections: Dict[str, Connection] = {}
+
+    for entity in map(lambda x: x.resource, entities):
+        if isinstance(entity, PackagingIntegration):
+            packagers[entity.id] = entity
+        elif isinstance(entity, Connection):
+            connections[entity.id] = entity
+        elif isinstance(entity, ModelPackaging) and entity.id == pack_id:
+            mp = entity
+
+    return mp, packagers, connections
+
+
+def _decode_connection(connection: Connection) -> None:
+
+    encoding = 'utf-8'
+    decode_fields = ['password', 'key_secret', 'key_id', 'public_key']
+
+    for f in decode_fields:
+        v: str = getattr(connection.spec, f)
+        if not v:
+            continue
+
+        try:
+            decoded = base64.b64decode(v, validate=True)
+        except Exception as e:
+            LOGGER.error(f'Unable to decode base64 .spec.{f} of connection {connection.id}')
+            raise e
+
+        try:
+            decoded_string = decoded.decode(encoding)
+        except Exception as e:
+            LOGGER.error(f'Unable to decode utf-8 .spec.{f} of connection {connection.id}')
+            raise e
+
+        setattr(connection.spec, f, decoded_string)
+
+
+def get_packager(
+        name: str, local: Dict[str, PackagingIntegration], remote_api: PackagingIntegrationClient
+) -> PackagingIntegration:
+    """
+    Fetch Packager entity by name looking in local manifests at first
+    and trying to fetch from web api after
+    :param name: name of packager
+    :param local: entities parsed from local manifests
+    :param remote_api: client to fetch packagers from API server
+    :return:
+    """
+    packager = local.get(name)
+    if not packager:
+        click.echo(
+            f'The {name} packager not found in the manifest files.'
+            f' Trying to retrieve it from API server'
+        )
+        packager = remote_api.get(name)
+    return packager
+
+
+def get_packager_targets(
+        targets: List[Target], connections: Dict[str, Connection], remote_api: ConnectionClient
+) -> List[PackagerTarget]:
+    """
+    Build targets for calling packager. Fetch and base64 decode connections by names using local manifest and
+    ODAHU connections API
+    :param targets:
+    :param connections:
+    :param remote_api:
+    :return:
+    """
+
+    packager_targets: List[PackagerTarget] = []
+
+    for t in targets:
+        conn = connections.get(t.connection_name)
+        if not conn:
+            click.echo(
+                f'The {t.connection_name} connection of target {t.name} not found in the manifest files.'
+                f' Trying to retrieve it from API server'
+            )
+            conn = remote_api.get_decrypted(t.connection_name)
+
+        _decode_connection(conn)
+
+        packager_targets.append(
+            PackagerTarget(conn, t.name)
+        )
+
+    return packager_targets
+
+
+def _deprecation_warning(is_target_disabled: bool):
+    if is_target_disabled is None:
+        click.echo('[FeatureWarning] Current behavior is to disable all packager targets for a local run. '
+                   'In future releases this behavior will be removed '
+                   'and all targets from ModelPackaging manifest will be enabled by default. '
+                   'Consider using --disable-target option to disable specific targets by name')
+    else:
+        click.echo('[FeatureWarning] --disable-package-targets/--no-disable-package-targets options '
+                   'are deprecated and will be removed in future releases. '
+                   'By default all targets will be enabled. '
+                   'Consider using --disable-target option to disable specific targets by name')
+
+
 @packaging_group.command()
 @click.option('--pack-id', '--id', help='Model packaging ID', required=True)
 @click.option('--manifest-file', '-f', type=click.Path(), multiple=True,
@@ -69,11 +201,14 @@ def cleanup_containers():
 @click.option('--artifact-path', type=click.Path(),
               help='Path to a training artifact')
 @click.option('--artifact-name', '-a', type=str, help='Override artifact name from file')
+# TODO Breaking Changes: remove --disable-package-targets/--no-disable-package-targets' options
 @click.option('--disable-package-targets/--no-disable-package-targets', 'is_target_disabled',
-              default=True, help='Disable all targets in packaging')
+              default=None, help='Disable all targets in packaging')
+@click.option('--disable-target', multiple=True,
+              help='Disable target in packaging')
 @pass_obj
 def run(client: ModelPackagingClient, pack_id: str, manifest_file: List[str], manifest_dir: List[str],
-        artifact_path: str, artifact_name: str, is_target_disabled: bool):
+        artifact_path: str, artifact_name: str, is_target_disabled:bool, disable_target: List[str]):
     """
     \b
     Start a packaging process locally.
@@ -82,21 +217,15 @@ def run(client: ModelPackagingClient, pack_id: str, manifest_file: List[str], ma
         * odahuflowctl local pack run --id wine
     \f
     """
-    entities: List[OdahuflowCloudResourceUpdatePair] = []
-    for file_path in manifest_file:
-        entities.extend(parse_resources_file(file_path).changes)
 
-    for dir_path in manifest_dir:
-        entities.extend(parse_resources_dir(dir_path))
+    _deprecation_warning(is_target_disabled)
 
-    mp: Optional[ModelPackaging] = None
+    if is_target_disabled is None:  # Backward compatibility
+        is_target_disabled = True
 
-    packagers: Dict[str, PackagingIntegration] = {}
-    for entity in map(lambda x: x.resource, entities):
-        if isinstance(entity, PackagingIntegration):
-            packagers[entity.id] = entity
-        elif isinstance(entity, ModelPackaging) and entity.id == pack_id:
-            mp = entity
+    entities: List[OdahuflowCloudResourceUpdatePair] = fetch_local_entities(manifest_file, manifest_dir)
+
+    mp, packagers, connections = parse_entities(entities, pack_id)
 
     if not mp:
         click.echo(
@@ -105,26 +234,25 @@ def run(client: ModelPackagingClient, pack_id: str, manifest_file: List[str], ma
         )
         mp = client.get(pack_id)
 
-    integration_name = mp.spec.integration_name
-    packager = packagers.get(integration_name)
-    if not packager:
-        click.echo(
-            f'The {integration_name} packager not found in the manifest files.'
-            f' Trying to retrieve it from API server'
-        )
-        packager = PackagingIntegrationClient.construct_from_other(client).get(integration_name)
+    packager = get_packager(
+        mp.spec.integration_name, packagers, PackagingIntegrationClient.construct_from_other(client)
+    )
 
     if artifact_name:
         mp.spec.artifact_name = artifact_name
         LOGGER.debug('Override the artifact name')
 
-    if is_target_disabled:
-        mp.spec.targets = []
+    if disable_target:
+        LOGGER.debug(f'Next targets are disabled: {", ".join(disable_target)}')
+    targets = get_packager_targets(
+        [t for t in mp.spec.targets if t.name not in disable_target and not is_target_disabled],
+        connections, ConnectionClient.construct_from_other(client)
+    )
 
     k8s_packager = K8sPackager(
         model_packaging=mp,
         packaging_integration=packager,
-        targets=[],
+        targets=targets,
     )
 
     result = start_package(k8s_packager, artifact_path)

--- a/packages/cli/odahuflow/cli/parsers/local/packaging.py
+++ b/packages/cli/odahuflow/cli/parsers/local/packaging.py
@@ -208,7 +208,7 @@ def _deprecation_warning(is_target_disabled: bool):
               help='Disable target in packaging')
 @pass_obj
 def run(client: ModelPackagingClient, pack_id: str, manifest_file: List[str], manifest_dir: List[str],
-        artifact_path: str, artifact_name: str, is_target_disabled:bool, disable_target: List[str]):
+        artifact_path: str, artifact_name: str, is_target_disabled: bool, disable_target: List[str]):
     """
     \b
     Start a packaging process locally.

--- a/packages/cli/odahuflow/cli/parsers/local/packaging.py
+++ b/packages/cli/odahuflow/cli/parsers/local/packaging.py
@@ -67,9 +67,6 @@ def fetch_local_entities(manifest_file, manifest_dir):
     Collect entities from manifest files in local FS and return a result
     Manifests can be collected from file or files inside a directory
     Manifests from different sources are combined together
-    :param manifest_file: manifest file
-    :param manifest_dir: directory with manifest files
-    :return:
     """
 
     entities: List[OdahuflowCloudResourceUpdatePair] = []

--- a/packages/cli/odahuflow/cli/parsers/local/packaging.py
+++ b/packages/cli/odahuflow/cli/parsers/local/packaging.py
@@ -62,7 +62,7 @@ def cleanup_containers():
     cleanup_packaging_docker_containers()
 
 
-def fetch_local_entities(manifest_file, manifest_dir):
+def fetch_local_entities(manifest_file: List[str], manifest_dir: List[str]) -> List[OdahuflowCloudResourceUpdatePair]:
     """
     Collect entities from manifest files in local FS and return a result
     Manifests can be collected from file or files inside a directory

--- a/packages/cli/odahuflow/cli/parsers/local/packaging.py
+++ b/packages/cli/odahuflow/cli/parsers/local/packaging.py
@@ -153,10 +153,9 @@ def get_packager_targets(
     """
     Build targets for calling packager. Fetch and base64 decode connections by names using local manifest and
     ODAHU connections API
-    :param targets:
-    :param connections:
-    :param remote_api:
-    :return:
+    :param targets: Targets from packaging manifest
+    :param connections: Connections found in local manifest files
+    :param remote_api: ConnectionClient to fetch missing Connections
     """
 
     packager_targets: List[PackagerTarget] = []

--- a/packages/cli/odahuflow/cli/parsers/local/packaging.py
+++ b/packages/cli/odahuflow/cli/parsers/local/packaging.py
@@ -18,7 +18,7 @@ Local packaging commands for odahuflow cli
 """
 import base64
 import logging
-from typing import List, Dict, NoReturn, Optional, Tuple
+from typing import List, Dict, Optional
 
 import click
 

--- a/packages/cli/tests/parsers/test_local_packaging.py
+++ b/packages/cli/tests/parsers/test_local_packaging.py
@@ -1,0 +1,200 @@
+import base64
+from typing import Any, Dict, List, Tuple
+from unittest.mock import Mock
+
+from dataclasses import dataclass
+import pytest
+import yaml
+from click.testing import CliRunner
+from odahuflow.cli.parsers.local.packaging import run
+from odahuflow.sdk.clients.api import WrongHttpStatusCode
+from odahuflow.sdk.local import packaging as packaging_sdk
+from odahuflow.sdk.models import ConnectionSpec, K8sPackager, ModelPackaging, ModelPackagingSpec, ModelPackagingStatus, \
+    PackagingIntegration, \
+    PackagerTarget, \
+    Target, \
+    Connection
+from pytest_mock import MockFixture
+
+PLAIN_VALUE = 'Value'
+
+conn1 = Connection(
+    id='conn1',
+    spec=ConnectionSpec(
+        key_id=base64.b64encode(bytes(PLAIN_VALUE, 'utf-8')).decode('utf-8'),
+        key_secret=base64.b64encode(bytes(PLAIN_VALUE, 'utf-8')).decode('utf-8'),
+        public_key=base64.b64encode(bytes(PLAIN_VALUE, 'utf-8')).decode('utf-8'),
+        password=base64.b64encode(bytes(PLAIN_VALUE, 'utf-8')).decode('utf-8'),
+    )
+)
+conn2 = Connection(
+    id='conn2',
+    spec=ConnectionSpec(
+        key_id=base64.standard_b64encode(bytes(PLAIN_VALUE, 'utf-8')).decode('utf-8'),
+        key_secret=base64.b64encode(bytes(PLAIN_VALUE, 'utf-8')).decode('utf-8'),
+        public_key=base64.b64encode(bytes(PLAIN_VALUE, 'utf-8')).decode('utf-8'),
+        password=base64.b64encode(bytes(PLAIN_VALUE, 'utf-8')).decode('utf-8'),
+    )
+)
+conn_d1 = Connection(
+    id='conn1',
+    spec=ConnectionSpec(
+        key_id=PLAIN_VALUE,
+        key_secret=PLAIN_VALUE,
+        public_key=PLAIN_VALUE,
+        password=PLAIN_VALUE,
+    )
+)
+conn_d2 = Connection(
+    id='conn2',
+    spec=ConnectionSpec(
+        key_id=PLAIN_VALUE,
+        key_secret=PLAIN_VALUE,
+        public_key=PLAIN_VALUE,
+        password=PLAIN_VALUE,
+    )
+)
+target_pull = Target("conn1", "docker-pull")
+target_push = Target("conn2", "docker-push")
+pi_target_pull = PackagerTarget(conn_d1, "docker-pull")
+pi_target_push = PackagerTarget(conn_d2, "docker-push")
+
+
+pack1 = ModelPackaging(
+    id='pack1',
+    spec=ModelPackagingSpec(
+        integration_name="pi",
+        targets=[target_pull, target_push]
+    ),
+    status=ModelPackagingStatus()
+)
+
+pi = PackagingIntegration(id="pi")
+
+
+@dataclass
+class I:
+    cmd: List[str]
+    local: List[Any]
+    remote: List[Any]
+
+
+@dataclass
+class E:
+    targets: List[PackagerTarget]
+    exit_code: int = 0
+    exc: Exception = None
+
+
+@dataclass
+class Case:
+    input: I
+    expected: E
+
+
+test_cases: List[Case] = [
+    Case(  # all manifests are locally stored, default run withot options
+        input=I(
+            cmd=["--pack-id", "pack1"],
+            local=[conn1, conn2, pi, pack1], remote=[]),
+        expected=E(targets=[])
+    ),
+    Case(  # no global targets disable
+        input=I(
+            cmd=["--pack-id", "pack1", "--no-disable-package-targets"],
+            local=[conn1, conn2, pi, pack1], remote=[]),
+        expected=E(targets=[pi_target_pull, pi_target_push])
+    ),
+    Case(  # no global targets disable, but specific target is disabled
+        input=I(
+            cmd=[
+                "--pack-id", "pack1", "--no-disable-package-targets",
+                "--disable-target", "docker-pull"
+            ],
+            local=[conn1, conn2, pi, pack1], remote=[]),
+        expected=E(targets=[pi_target_push])
+    ),
+    Case(  # manifests on the server
+        input=I(
+            cmd=["--pack-id", "pack1"],
+            local=[], remote=[conn1, conn2, pi, pack1]),
+        expected=E(targets=[])
+    ),
+    Case(  # some manifests are local stored, some in the server
+        input=I(
+            cmd=["--pack-id", "pack1"],
+            local=[pi, conn2], remote=[conn1, pack1]),
+        expected=E(targets=[])
+    ),
+    Case(  # pack not found
+        input=I(
+            cmd=["--pack-id", "pack1"],
+            local=[], remote=[conn1, conn2, pi]),
+        expected=E(targets=[], exit_code=1, exc=WrongHttpStatusCode(404, {"message": f"Not found {pack1.id}"}))
+    ),
+    Case(  # no global targets disable, conn missed
+        input=I(
+            cmd=["--pack-id", "pack1", "--no-disable-package-targets"],
+            local=[conn1, pi, pack1], remote=[]),
+        expected=E(targets=[], exit_code=1, exc=WrongHttpStatusCode(404, {"message": f"Not found {conn2.id}"}))
+    ),
+]
+
+
+@pytest.mark.parametrize("test_case", test_cases)
+def test_run_targets(cli_runner: CliRunner, test_case: Case, mocker: MockFixture):
+
+    input_d, expected = test_case.input, test_case.expected
+    command_args, local, remote = input_d.cmd, input_d.local, input_d.remote
+
+    # Prepare remote API client mocks
+    api_client = Mock()
+
+    def api_retrieve(id_: str):
+        for en in remote:
+            if id_ == en.id:
+                return en
+        raise WrongHttpStatusCode(404, {"message": f"Not found {id_}"})
+
+    api_client.get = Mock(side_effect=api_retrieve)
+    api_client.get_decrypted = Mock(side_effect=api_retrieve)
+
+    mocker.patch(
+        "odahuflow.cli.parsers.local.packaging.PackagingIntegrationClient.construct_from_other",
+        new=Mock(return_value=api_client)
+    )
+    mocker.patch(
+        "odahuflow.cli.parsers.local.packaging.ConnectionClient.construct_from_other",
+        new=Mock(return_value=api_client)
+    )
+
+    # Prepare entities that are stored locally
+    with cli_runner.isolated_filesystem():
+        with open('manifest.yaml', 'w') as f:
+            docs = []
+            for en in local:
+                d = en.to_dict()
+                d["kind"] = en.__class__.__name__
+                docs.append(d)
+            yaml.safe_dump_all(docs, f)
+        if "--manifest-file" not in command_args:
+            command_args += ["--manifest-file", "manifest.yaml"]
+
+        # Run
+        m: Mock = mocker.patch("odahuflow.cli.parsers.local.packaging.start_package")
+        result = cli_runner.invoke(run, command_args, obj=api_client)
+
+        # Assert expectations
+        if expected.exc is None:
+            assert result.exit_code == 0
+            assert result.exception is None
+
+            m.assert_called_once()
+            mp_json_actual, _ = m.call_args[0]  # type: K8sPackager, Any
+
+            assert mp_json_actual.targets == expected.targets
+
+        else:
+            assert result.exit_code == 1
+            assert isinstance(result.exception, type(expected.exc))
+            assert str(expected.exc) == str(result.exception)

--- a/packages/cli/tests/parsers/test_local_packaging.py
+++ b/packages/cli/tests/parsers/test_local_packaging.py
@@ -93,7 +93,7 @@ class Case:
 
 
 test_cases: List[Case] = [
-    Case(  # all manifests are locally stored, default run withot options
+    Case(  # all manifests are locally stored, default run without options
         input=I(
             cmd=["--pack-id", "pack1"],
             local=[conn1, conn2, pi, pack1], remote=[]),

--- a/packages/sdk/odahuflow/sdk/local/docker_utils.py
+++ b/packages/sdk/odahuflow/sdk/local/docker_utils.py
@@ -47,7 +47,7 @@ def stream_container_logs(container: Container) -> None:
     logs = container.logs(stream=True, follow=True)
     for log in logs:
         for line in log.splitlines():
-            print(line.decode())
+            print(f'[Container {container.id[:5]}] {line.decode()}')
 
 
 def convert_labels_to_filter(labels: Dict[str, str]) -> List[str]:

--- a/packages/sdk/odahuflow/sdk/local/packaging.py
+++ b/packages/sdk/odahuflow/sdk/local/packaging.py
@@ -10,6 +10,7 @@ from docker.types import Mount
 from odahuflow.sdk import config
 from odahuflow.sdk.local.docker_utils import stream_container_logs, \
     convert_labels_to_filter, cleanup_docker_containers, PACKAGING_DOCKER_LABELS, raise_error_if_container_failed
+from odahuflow.sdk.logger import is_verbose_enabled
 from odahuflow.sdk.models import K8sPackager
 
 PACKAGER_CONF_FILE_PATH = 'mp.json'
@@ -52,7 +53,7 @@ def start_package(packager: K8sPackager, artifact_path: str) -> Dict[str, Any]:
             ARTIFACT_PATH,
             # specified path for Docker Linux Container ignoring OS
             str(PurePosixPath(ARTIFACT_PATH, PACKAGER_CONF_FILE_PATH)),
-        ],
+        ] + [v for v in ("--verbose",) if is_verbose_enabled()],
         mounts=[
             Mount(ARTIFACT_PATH, artifact_path, type="bind"),
             Mount("/var/run/docker.sock", "/var/run/docker.sock", type="bind")


### PR DESCRIPTION
* We added ``odahuflowctl local pack run`` command's new option ``--disable-target`` that allows you disable targets
  which will be passed to packager process. You can use multiple options at once. For example:
  ``odahuflowctl local pack run ... --disable-target=docker-pull --disable-target=docker-push``.
* ``odahuflowctl local pack run`` command's options ``--disable-package-targets/--no-disable-package-targets`` are
  deprecated.
* ``odahuflowctl local pack run`` behavior that implicitly disable all targets by default is deprecated.