### PR TITLE
If S3 KMS is enabled then MD5 corruption error

### DIFF
--- a/packages/operator/go.mod
+++ b/packages/operator/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Masterminds/squirrel v1.4.0
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/aspenmesh/istio-client-go v0.0.0-20190426173040-3e73c27b9ace
-	github.com/aws/aws-sdk-go v1.31.12
+	github.com/aws/aws-sdk-go v1.32.11
 	github.com/awslabs/amazon-ecr-credential-helper v0.3.1
 	github.com/banzaicloud/bank-vaults/pkg/sdk v0.3.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
@@ -32,9 +32,9 @@ require (
 	github.com/pborman/uuid v1.2.0
 	github.com/pierrec/lz4 v2.3.0+incompatible // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/common v0.9.1
+	github.com/prometheus/common v0.10.0
 	github.com/rakyll/statik v0.1.6
-	github.com/rclone/rclone v1.52.0
+	github.com/rclone/rclone v1.53.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.0

--- a/packages/operator/pkg/rclone/s3.go
+++ b/packages/operator/pkg/rclone/s3.go
@@ -39,6 +39,10 @@ func createS3config(configName string, conn *v1alpha1.ConnectionSpec) (*FileDesc
 		"bucket_acl":        "private",
 		"access_key_id":     conn.KeyID,
 		"secret_access_key": conn.KeySecret,
+		// https://github.com/rclone/rclone/issues/1824
+		// Workaround can be replaced after rclone v1.54 release
+		// with option server_side_encryption: aws:kms
+		"upload_cutoff": 0,
 	}, true, false); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* Workaround can be replaced after rclone v1.54 release with option server_side_encryption: aws:kms
* https://github.com/rclone/rclone/issues/1824