### PR TITLE
[#434] Fix Knative Revisions Spam

### DIFF
--- a/packages/operator/controllers/modeldeployment_controller_test.go
+++ b/packages/operator/controllers/modeldeployment_controller_test.go
@@ -161,8 +161,8 @@ func (s *ModelDeploymentControllerSuite) TestReconcile() {
 
 	configurationLabels := knativeConfiguration.Spec.Template.ObjectMeta.Labels
 	s.Assertions.Len(configurationLabels, 5)
-	s.Assertions.Contains(configurationLabels, DodelNameAnnotationKey)
-	s.Assertions.Equal(md.Name, configurationLabels[DodelNameAnnotationKey])
+	s.Assertions.Contains(configurationLabels, ModelNameAnnotationKey)
+	s.Assertions.Equal(md.Name, configurationLabels[ModelNameAnnotationKey])
 
 	podSpec := knativeConfiguration.Spec.Template.Spec
 	s.Assertions.Len(podSpec.Containers, 1)
@@ -281,9 +281,7 @@ func (s *ModelDeploymentControllerSuite) createDeployment(md *odahuflowv1alpha1.
 	return func() { s.k8sClient.Delete(context.TODO(), md) }
 }
 
-func (s *ModelDeploymentControllerSuite) getKnativeConfiguration(md *odahuflowv1alpha1.ModelDeployment) (
-	*knservingv1.Configuration,
-) {
+func (s *ModelDeploymentControllerSuite) getKnativeConfiguration(md *odahuflowv1alpha1.ModelDeployment) *knservingv1.Configuration {
 	configuration := &knservingv1.Configuration{}
 	configurationKey := types.NamespacedName{Name: KnativeConfigurationName(md), Namespace: md.Namespace}
 	s.Assertions.Eventually(

--- a/packages/operator/controllers/modeldeployment_controller_test.go
+++ b/packages/operator/controllers/modeldeployment_controller_test.go
@@ -281,7 +281,8 @@ func (s *ModelDeploymentControllerSuite) createDeployment(md *odahuflowv1alpha1.
 	return func() { s.k8sClient.Delete(context.TODO(), md) }
 }
 
-func (s *ModelDeploymentControllerSuite) getKnativeConfiguration(md *odahuflowv1alpha1.ModelDeployment) *knservingv1.Configuration {
+func (s *ModelDeploymentControllerSuite) getKnativeConfiguration(md *odahuflowv1alpha1.ModelDeployment,
+) *knservingv1.Configuration {
 	configuration := &knservingv1.Configuration{}
 	configurationKey := types.NamespacedName{Name: KnativeConfigurationName(md), Namespace: md.Namespace}
 	s.Assertions.Eventually(

--- a/packages/operator/controllers/modeldeployment_event_hadler.go
+++ b/packages/operator/controllers/modeldeployment_event_hadler.go
@@ -53,7 +53,7 @@ func (e *EnqueueRequestForImplicitOwner) Generic(evt event.GenericEvent, q workq
 
 func (e *EnqueueRequestForImplicitOwner) addEvent(meta metav1.Object, q workqueue.RateLimitingInterface) {
 	labels := meta.GetLabels()
-	name, ok := labels[DodelNameAnnotationKey]
+	name, ok := labels[ModelNameAnnotationKey]
 	if !ok {
 		return
 	}

--- a/packages/operator/controllers/modelpackaging_controller.go
+++ b/packages/operator/controllers/modelpackaging_controller.go
@@ -249,11 +249,6 @@ func (r *ModelPackagingReconciler) reconcileTaskRun(
 		return nil, err
 	}
 
-	if err := odahuflow.StoreHash(taskRun); err != nil {
-		log.Error(err, "Cannot apply obj hash")
-		return nil, err
-	}
-
 	found := &tektonv1beta1.TaskRun{}
 	err = r.Get(context.TODO(), types.NamespacedName{
 		Name: taskRun.Name, Namespace: r.packagingConfig.Namespace,
@@ -283,11 +278,6 @@ func (r *ModelPackagingReconciler) createResultConfigMap(packagingCR *odahuflowv
 	}
 
 	if err := controllerutil.SetControllerReference(packagingCR, resultCM, r.scheme); err != nil {
-		return err
-	}
-
-	if err := odahuflow.StoreHash(resultCM); err != nil {
-		log.Error(err, "Cannot apply obj hash")
 		return err
 	}
 

--- a/packages/operator/controllers/modeltraining_controller.go
+++ b/packages/operator/controllers/modeltraining_controller.go
@@ -278,11 +278,6 @@ func (r *ModelTrainingReconciler) reconcileTaskRun(
 		return nil, err
 	}
 
-	if err := odahuflow.StoreHash(taskRun); err != nil {
-		log.Error(err, "Cannot apply obj hash")
-		return nil, err
-	}
-
 	found := &tektonv1beta1.TaskRun{}
 	err = r.Get(context.TODO(), types.NamespacedName{
 		Name: taskRun.Name, Namespace: r.trainingConfig.Namespace,
@@ -311,11 +306,6 @@ func (r *ModelTrainingReconciler) createResultConfigMap(trainingCR *odahuflowv1a
 	}
 
 	if err := controllerutil.SetControllerReference(trainingCR, resultCM, r.scheme); err != nil {
-		return err
-	}
-
-	if err := odahuflow.StoreHash(resultCM); err != nil {
-		log.Error(err, "Cannot apply obj hash")
 		return err
 	}
 

--- a/packages/operator/pkg/odahuflow/k8s.go
+++ b/packages/operator/pkg/odahuflow/k8s.go
@@ -17,13 +17,7 @@
 package odahuflow
 
 import (
-	"crypto/sha512"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 const (
@@ -47,59 +41,4 @@ func GenerateTrainingResultCMName(mtID string) string {
 
 func GenerateDeploymentConnectionSecretName(connName string) string {
 	return fmt.Sprintf("%s-regsecret", connName)
-}
-
-// Compute hash and store it in the annotations
-func StoreHash(obj metav1.Object) error {
-	h := sha512.New()
-	jsonData, err := json.Marshal(obj)
-	if err != nil {
-		return err
-	}
-	_, err = h.Write(jsonData)
-	if err != nil {
-		return err
-	}
-
-	annotations := map[string]string{}
-	if obj.GetAnnotations() != nil {
-		for k, v := range obj.GetAnnotations() {
-			annotations[k] = v
-		}
-	}
-	annotations[LastAppliedHashAnnotation] = base64.StdEncoding.EncodeToString(h.Sum(nil))
-
-	obj.SetAnnotations(annotations)
-
-	return nil
-}
-
-// Compute hash and store it in the annotations
-func StoreHashKnative(obj *knservingv1.Configuration) error {
-	h := sha512.New()
-	jsonData, err := json.Marshal(obj)
-	if err != nil {
-		return err
-	}
-
-	_, err = h.Write(jsonData)
-	if err != nil {
-		return err
-	}
-
-	annotations := map[string]string{}
-	if obj.GetAnnotations() != nil {
-		for k, v := range obj.GetAnnotations() {
-			annotations[k] = v
-		}
-	}
-	annotations[LastAppliedHashAnnotation] = base64.StdEncoding.EncodeToString(h.Sum(nil))
-
-	obj.SetAnnotations(annotations)
-
-	return nil
-}
-
-func ObjsEqualByHash(firstObj, secondObj metav1.Object) bool {
-	return firstObj.GetAnnotations()[LastAppliedHashAnnotation] == secondObj.GetAnnotations()[LastAppliedHashAnnotation]
 }

--- a/packages/tests/e2e/robot/tests/api/resources/training_packaging/valid/training.mlflow-gpu.not_default.yaml
+++ b/packages/tests/e2e/robot/tests/api/resources/training_packaging/valid/training.mlflow-gpu.not_default.yaml
@@ -18,9 +18,9 @@ spec:
     limits:
       cpu: 3
       memory: 2Gi
-      gpu: 2
+      gpu: 1
     requests:
       cpu: 3
       memory: 2Gi
-      gpu: 2
+      gpu: 1
   vcsName: odahu-flow-examples


### PR DESCRIPTION
Explanation: apparently after upgrading Knative Operator version, it started to fill a couple of additional fields in Knative Configuration. So when ODAHU operator creates a Configuration, Knative Operator adds these fields. After that ODAHU Operator detects this change by comparing hashes of desired Configuration (without the added fields) and actual Configuration in K8s (with the fields). It thinks that Configuration is outdated and updates it with desired spec. 

This approach now changed so that ODAHU operator would discover outdated configuration by attached annotation with `ModelDeployment` `resourceVersion` it bases on. So every time we create/update Knative Confiiguration we attach a `resourceVersion` of ModelDeployment. On further runs  of reconcilation loop we only update the Configuration if current ModelDeployment `resourceVersion` updated. That guarantees that ODAHU operator only reacts to changes in our domain and doesn't interfere with other operators.

- [x] The same approach should be applied to detect changes in ModelRoute reconcilation
- [x] To reconcile K8s Service and Endpoints we can "honestly" align found objects with desired state with no hashes, version or other mechanisms to detect changes.

Fixes #434