### PR TITLE
fix: deleted generation of default IDs if id is not passed, (ID is required)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,137 @@
+version: 2.1
+jobs:
+  vulnerabilities:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+      - run: sudo make install-vulnerabilities-checker
+      - run: make check-vulnerabilities
+  python:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+      - run:
+          name: Setup miniconda
+          command: |
+            wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+            bash miniconda.sh -b -p $HOME/miniconda
+      - run:
+          name: Install deps
+          command: |
+            source "$HOME/miniconda/etc/profile.d/conda.sh"
+            make install-all
+            make install-python-tests
+            make install-python-linter
+      - run:
+          name: Code coverage
+          command: |
+            source "$HOME/miniconda/etc/profile.d/conda.sh"
+            pip install codecov
+            pip install pytest-cov
+      - run:
+          name: Lint
+          command: |
+            make python-lint
+      - run:
+          name: Test
+          command: |
+            source "$HOME/miniconda/etc/profile.d/conda.sh"
+            make python-unittests
+            bash <(curl -s https://codecov.io/bash) -cF python
+  operator:
+    machine:
+      image: ubuntu-2004:202010-01
+    working_directory: /home/circleci/go/src/github.com/odahu/odahu-flow
+    steps:
+      - checkout
+      - run:
+          name: Setup deps
+          command: |
+            sudo apt-get update -qq
+            sudo apt-get install pigz golang-1.14
+            wget -q https://github.com/golangci/golangci-lint/releases/download/v1.30.0/golangci-lint-1.30.0-linux-amd64.tar.gz -O /tmp/golangci-lint.tar.gz
+            sudo tar -zxvf /tmp/golangci-lint.tar.gz -C /usr/local/
+            sudo mv /usr/local/golangci-lint*/golangci-lint /usr/bin/golangci-lint
+            wget -q https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_amd64.tar.gz -O /tmp/kubebuilder.tar.gz
+            sudo tar -zxvf /tmp/kubebuilder.tar.gz -C /usr/local/
+            sudo mv /usr/local/kubebuilder_* /usr/local/kubebuilder
+            wget -q https://github.com/swaggo/swag/releases/download/v1.6.5/swag_1.6.5_Linux_x86_64.tar.gz -O /tmp/swag.tar.gz
+            sudo tar -zxvf /tmp/swag.tar.gz -C /usr/local/
+            sudo mv /usr/local/swag /usr/bin/
+            wget -q https://github.com/gotestyourself/gotestsum/releases/download/v0.5.0/gotestsum_0.5.0_linux_amd64.tar.gz -O /tmp/gotestsum.tar.gz
+            sudo tar -zxvf /tmp/gotestsum.tar.gz -C /usr/local/
+            sudo mv /usr/local/gotestsum* /usr/bin/gotestsum
+            go get github.com/t-yuki/gocover-cobertura
+      - run:
+          name: Test
+          command: |
+            cd packages/operator
+            make test
+            bash <(curl -s https://codecov.io/bash) -cF go # (for codecov)
+  feedback_aggregator:
+    docker:
+      - image: circleci/golang:1.14
+    working_directory: /go/src/github.com/odahu/odahu-flow
+    steps:
+      - checkout
+      - run:
+          name: Setup deps
+          command: |
+            sudo apt-get update -qq
+            wget -q https://github.com/golangci/golangci-lint/releases/download/v1.30.0/golangci-lint-1.30.0-linux-amd64.tar.gz -O /tmp/golangci-lint.tar.gz
+            sudo tar -zxvf /tmp/golangci-lint.tar.gz -C /usr/local/
+            sudo mv /usr/local/golangci-lint*/golangci-lint /usr/bin/golangci-lint
+            sudo wget -q https://github.com/golang/dep/releases/download/v0.5.1/dep-linux-amd64 -O /usr/local/bin/dep
+            sudo chmod +x /usr/local/bin/dep
+            wget -q https://github.com/gotestyourself/gotestsum/releases/download/v0.3.4/gotestsum_0.3.4_linux_amd64.tar.gz -O /tmp/gotestsum.tar.gz
+            sudo tar -zxvf /tmp/gotestsum.tar.gz -C /usr/local/
+            sudo mv /usr/local/gotestsum* /usr/bin/gotestsum
+            go get github.com/t-yuki/gocover-cobertura
+      - run:
+          name: Lint
+          command: |
+            cd packages/feedback
+            dep ensure -v -vendor-only
+            make lint
+      - run:
+          name: Test
+          command: |
+            cd packages/feedback
+            dep ensure -v -vendor-only
+            make test
+            bash <(curl -s https://codecov.io/bash) -cF go # (for codecov)
+  build:
+    docker:
+      - image: cimg/base:2021.01
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: make docker-build-robot-tests
+      - run: make docker-build-feedback-collector
+      - run: make docker-build-feedback-rq-catcher
+      - run: make docker-build-api
+      - run: make docker-build-operator
+      - run: make docker-build-model-trainer
+      - run: make docker-build-model-packager
+      - run: make docker-build-service-catalog
+
+workflows:
+  main:
+    jobs:
+      - vulnerabilities
+      - python
+      - operator
+      - feedback_aggregator
+      - build:
+          context:
+            - hub.docker.com
+          requires:
+            - vulnerabilities
+            - python
+            - operator
+            - feedback_aggregator

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -4,7 +4,7 @@ IMG ?= controller:latest
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 ODAHUFLOW_OPERATOR_GENERATED_ENTITIES = ../../helms/odahu-flow-core/templates/operator/generated
-LINTER_ADDITIONAL_ARGS =
+LINTER_ADDITIONAL_ARGS="--verbose"
 KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=600s
 
 ODAHUFLOW_NAMESPACE=odahu-flow

--- a/packages/operator/pkg/apiserver/routes/v1/connection/connection_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/connection/connection_validation.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api"
-	uuid "github.com/nu7hatch/gouuid"
 	"github.com/odahu/odahu-flow/packages/operator/pkg/apis/connection"
 	"github.com/odahu/odahu-flow/packages/operator/pkg/validation"
 	"go.uber.org/multierr"

--- a/packages/operator/pkg/apiserver/routes/v1/connection/connection_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/connection/connection_validation.go
@@ -68,16 +68,6 @@ func NewConnValidator(keyEvaluator PublicKeyEvaluator) *ConnValidator {
 }
 
 func (cv *ConnValidator) ValidatesAndSetDefaults(conn *connection.Connection) (err error) {
-	if len(conn.ID) == 0 {
-		u4, uuidErr := uuid.NewV4()
-		if uuidErr != nil {
-			err = multierr.Append(err, uuidErr)
-		} else {
-			conn.ID = fmt.Sprintf(defaultIDTemplate, conn.Spec.Type, u4.String())
-			logC.Info("Connection id is empty. Generate a default value", "id", conn.ID)
-		}
-	}
-
 	err = multierr.Append(validation.ValidateID(conn.ID), err)
 	err = multierr.Append(cv.validateBase64Fields(conn), err)
 

--- a/packages/operator/pkg/apiserver/routes/v1/connection/connection_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/connection/connection_validation_test.go
@@ -57,19 +57,6 @@ func TestConnectionValidationSuite(t *testing.T) {
 	suite.Run(t, new(ConnectionValidationSuite))
 }
 
-func (s *ConnectionValidationSuite) TestIDGeneration() {
-	conn := &connection.Connection{
-		Spec: v1alpha1.ConnectionSpec{
-			Type:      "not-existed",
-			URI:       connURI,
-			Reference: connReference,
-			KeySecret: creds,
-		},
-	}
-	_ = s.v.ValidatesAndSetDefaults(conn)
-	s.g.Expect(conn.ID).ShouldNot(BeEmpty())
-}
-
 func (s *ConnectionValidationSuite) TestEmptyURL() {
 	conn := &connection.Connection{
 		Spec: v1alpha1.ConnectionSpec{

--- a/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation.go
@@ -23,7 +23,6 @@ import (
 	"github.com/odahu/odahu-flow/packages/operator/pkg/validation"
 	"reflect"
 
-	uuid "github.com/nu7hatch/gouuid"
 	odahuflowv1alpha1 "github.com/odahu/odahu-flow/packages/operator/api/v1alpha1"
 	"github.com/odahu/odahu-flow/packages/operator/pkg/apis/packaging"
 	conn_repository "github.com/odahu/odahu-flow/packages/operator/pkg/repository/connection"

--- a/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation.go
@@ -95,16 +95,6 @@ func (mpv *MpValidator) ValidateAndSetDefaults(mp *packaging.ModelPackaging) (er
 }
 
 func (mpv *MpValidator) validateMainParameters(mp *packaging.ModelPackaging) (err error) {
-	if len(mp.ID) == 0 {
-		u4, uuidErr := uuid.NewV4()
-		if uuidErr != nil {
-			err = multierr.Append(err, uuidErr)
-		} else {
-			mp.ID = fmt.Sprintf(defaultIDTemplate, mp.Spec.ArtifactName, mp.Spec.IntegrationName, u4.String())
-			logMP.Info("Model packaging id is empty. Generate a default value", "id", mp.ID)
-		}
-	}
-
 	err = multierr.Append(err, validation.ValidateID(mp.ID))
 
 	if len(mp.Spec.Image) == 0 {

--- a/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation_test.go
@@ -201,15 +201,6 @@ func TestModelPackagingValidationSuite(t *testing.T) {
 	suite.Run(t, new(ModelPackagingValidationSuite))
 }
 
-func (s *ModelPackagingValidationSuite) TestMpIDGeneration() {
-	ti := &packaging.ModelPackaging{
-		Spec: packaging.ModelPackagingSpec{},
-	}
-
-	_ = s.validator.ValidateAndSetDefaults(ti)
-	s.g.Expect(ti.ID).ShouldNot(BeEmpty())
-}
-
 func (s *ModelPackagingValidationSuite) TestMpIDExplicitly() {
 	id := "some-id"
 	mp := &packaging.ModelPackaging{

--- a/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation_test.go
@@ -361,7 +361,7 @@ func (s *ModelPackagingValidationSuite) TestMpRequiredTargets() {
 
 func (s *ModelPackagingValidationSuite) TestMpDefaultTargets() {
 	ti := &packaging.ModelPackaging{
-	    id: "valid-id"
+	    id: "valid-id",
 		Spec: packaging.ModelPackagingSpec{
 			IntegrationName:  piIDMpValid,
 			ArtifactName:     "test",

--- a/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation_test.go
@@ -94,7 +94,7 @@ var (
 	}
 	validNodeSelector = map[string]string{"mode": "valid"}
 	validPackaging    = packaging.ModelPackaging{
-	    id: "valid-id"
+	    id: "valid-id",
 		Spec: packaging.ModelPackagingSpec{
 			IntegrationName:  piIDMpValid,
 			ArtifactName:     "test",

--- a/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation_test.go
@@ -94,6 +94,7 @@ var (
 	}
 	validNodeSelector = map[string]string{"mode": "valid"}
 	validPackaging    = packaging.ModelPackaging{
+	    id: "valid-id"
 		Spec: packaging.ModelPackagingSpec{
 			IntegrationName:  piIDMpValid,
 			ArtifactName:     "test",
@@ -360,6 +361,7 @@ func (s *ModelPackagingValidationSuite) TestMpRequiredTargets() {
 
 func (s *ModelPackagingValidationSuite) TestMpDefaultTargets() {
 	ti := &packaging.ModelPackaging{
+	    id: "valid-id"
 		Spec: packaging.ModelPackagingSpec{
 			IntegrationName:  piIDMpValid,
 			ArtifactName:     "test",
@@ -570,17 +572,17 @@ func (s *ModelPackagingValidationSuite) TestValidateNodeSelector_nil() {
 
 // Packaging object has valid node selector that exists in config
 func (s *ModelPackagingValidationSuite) TestValidateNodeSelector_Valid() {
-	mt := validPackaging
-	err := s.validator.ValidateAndSetDefaults(&mt)
+	mp := validPackaging
+	err := s.validator.ValidateAndSetDefaults(&mp)
 	s.Assertions.Nil(err)
 }
 
 // Packaging object has invalid node selector that does not exist in config
 // Expect validator to return exactly one error
 func (s *ModelPackagingValidationSuite) TestValidateNodeSelector_Invalid() {
-	mt := validPackaging
-	mt.Spec.NodeSelector = map[string]string{"mode": "invalid"}
-	err := s.validator.ValidateAndSetDefaults(&mt)
+	mp := validPackaging
+	mp.Spec.NodeSelector = map[string]string{"mode": "invalid"}
+	err := s.validator.ValidateAndSetDefaults(&mp)
 	s.Assertions.NotNil(err)
 	s.Assertions.Len(multierr.Errors(err), 1)
 }

--- a/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation_test.go
@@ -94,7 +94,7 @@ var (
 	}
 	validNodeSelector = map[string]string{"mode": "valid"}
 	validPackaging    = packaging.ModelPackaging{
-	    id: "valid-id",
+	    ID: "valid-id",
 		Spec: packaging.ModelPackagingSpec{
 			IntegrationName:  piIDMpValid,
 			ArtifactName:     "test",
@@ -361,7 +361,7 @@ func (s *ModelPackagingValidationSuite) TestMpRequiredTargets() {
 
 func (s *ModelPackagingValidationSuite) TestMpDefaultTargets() {
 	ti := &packaging.ModelPackaging{
-	    id: "valid-id",
+	    ID: "valid-id",
 		Spec: packaging.ModelPackagingSpec{
 			IntegrationName:  piIDMpValid,
 			ArtifactName:     "test",

--- a/packages/operator/pkg/apiserver/routes/v1/packaging/packaging_integration_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/packaging/packaging_integration_validation.go
@@ -29,7 +29,6 @@ import (
 
 const (
 	ValidationPiErrorMessage               = "Validation of packaging integration is failed"
-	EmptyIDErrorMessage                    = "id must be nonempty"
 	EmptyEntrypointErrorMessage            = "entrypoint must be nonempty"
 	EmptyDefaultImageErrorMessage          = "default image must be nonempty"
 	TargetEmptyConnectionTypesErrorMessage = "%s target must have at least one connection type"
@@ -101,10 +100,6 @@ func (mpv *PiValidator) validateTargetsSchema(pi *packaging.PackagingIntegration
 }
 
 func (mpv *PiValidator) validateMainParameters(pi *packaging.PackagingIntegration) (err error) {
-	if len(pi.ID) == 0 {
-		err = multierr.Append(err, errors.New(EmptyIDErrorMessage))
-	}
-
 	err = multierr.Append(err, validation.ValidateID(pi.ID))
 
 	if len(pi.Spec.Entrypoint) == 0 {

--- a/packages/operator/pkg/apiserver/routes/v1/packaging/packaging_intergration_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/packaging/packaging_intergration_validation_test.go
@@ -48,7 +48,7 @@ func (s *PackagingIntegrationValidationSuite) TestPiIDValidation() {
 
 	err := pack_route.NewPiValidator().ValidateAndSetDefaults(pi)
 	s.g.Expect(err).Should(HaveOccurred())
-	s.g.Expect(err.Error()).Should(ContainSubstring(pack_route.EmptyIDErrorMessage))
+	s.g.Expect(err.Error()).Should(ContainSubstring(validation.ValidateEmpty("ID", id)))
 }
 
 func (s *PackagingIntegrationValidationSuite) TestPiEntrypointValidation() {

--- a/packages/operator/pkg/apiserver/routes/v1/packaging/packaging_intergration_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/packaging/packaging_intergration_validation_test.go
@@ -48,7 +48,7 @@ func (s *PackagingIntegrationValidationSuite) TestPiIDValidation() {
 
 	err := pack_route.NewPiValidator().ValidateAndSetDefaults(pi)
 	s.g.Expect(err).Should(HaveOccurred())
-	s.g.Expect(err.Error()).Should(ContainSubstring(validation.ValidateEmpty("ID", id)))
+	s.g.Expect(err.Error()).Should(ContainSubstring(validation.EmptyValueStringError, "ID"))
 }
 
 func (s *PackagingIntegrationValidationSuite) TestPiEntrypointValidation() {

--- a/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation.go
@@ -19,7 +19,6 @@ package training
 import (
 	"errors"
 	"fmt"
-	uuid "github.com/nu7hatch/gouuid"
 	odahuflowv1alpha1 "github.com/odahu/odahu-flow/packages/operator/api/v1alpha1"
 	"github.com/odahu/odahu-flow/packages/operator/pkg/apis/connection"
 	"github.com/odahu/odahu-flow/packages/operator/pkg/apis/training"

--- a/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation.go
@@ -121,20 +121,9 @@ func (mtv *MtValidator) validateTrainingName(name string) (err error) {
 }
 
 func (mtv *MtValidator) validateMainParams(mt *training.ModelTraining) (err error) {
+	err = multierr.Append(err, validation.ValidateID(mt.ID))
 	err = multierr.Append(err, mtv.validateTrainingName(mt.Spec.Model.Name))
 	err = multierr.Append(err, mtv.validateTrainingVersion(mt.Spec.Model.Version))
-
-	if len(mt.ID) == 0 {
-		u4, uuidErr := uuid.NewV4()
-		if uuidErr != nil {
-			err = multierr.Append(err, uuidErr)
-		} else {
-			mt.ID = fmt.Sprintf(defaultIDTemplate, mt.Spec.Model.Name, mt.Spec.Model.Version, u4.String())
-			logMT.Info("Training id is empty. Generate a default value", "id", mt.ID)
-		}
-	}
-
-	err = multierr.Append(err, validation.ValidateID(mt.ID))
 
 	if len(mt.Spec.Model.ArtifactNameTemplate) == 0 {
 		logMT.Info("Artifact output template is empty. Set the default value",

--- a/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation_test.go
@@ -186,15 +186,6 @@ func (s *ModelTrainingValidationSuite) TestMtMtImageExplicitly() {
 	s.g.Expect(mt.Spec.Image).To(Equal(image))
 }
 
-func (s *ModelTrainingValidationSuite) TestMtIDGeneration() {
-	mt := &training.ModelTraining{
-		Spec: v1alpha1.ModelTrainingSpec{},
-	}
-
-	_ = s.validator.ValidatesAndSetDefaults(mt)
-	s.g.Expect(mt.ID).ShouldNot(BeEmpty())
-}
-
 func (s *ModelTrainingValidationSuite) TestMtExplicitMTReference() {
 	mtExplicitReference := "test-ref"
 	mt := &training.ModelTraining{

--- a/packages/operator/pkg/apiserver/routes/v1/training/toolchain_integration_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/training/toolchain_integration_validation.go
@@ -19,7 +19,6 @@ package training
 import (
 	"errors"
 	"fmt"
-	uuid "github.com/nu7hatch/gouuid"
 	"github.com/odahu/odahu-flow/packages/operator/pkg/apis/training"
 	"github.com/odahu/odahu-flow/packages/operator/pkg/validation"
 	"go.uber.org/multierr"

--- a/packages/operator/pkg/apiserver/routes/v1/training/toolchain_integration_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/training/toolchain_integration_validation.go
@@ -39,16 +39,6 @@ func NewTiValidator() *TiValidator {
 }
 
 func (tiv *TiValidator) ValidatesAndSetDefaults(ti *training.ToolchainIntegration) (err error) {
-	if len(ti.ID) == 0 {
-		u4, uuidErr := uuid.NewV4()
-		if uuidErr != nil {
-			err = multierr.Append(err, uuidErr)
-		} else {
-			ti.ID = u4.String()
-			logTI.Info("Toolchain integration id is empty. Generate a default value", "id", ti.ID)
-		}
-	}
-
 	err = multierr.Append(err, validation.ValidateID(ti.ID))
 
 	if len(ti.Spec.Entrypoint) == 0 {

--- a/packages/operator/pkg/apiserver/routes/v1/training/toolchain_intergration_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/training/toolchain_intergration_validation_test.go
@@ -44,15 +44,6 @@ func TestToolchainIntegrationValidationSuite(t *testing.T) {
 	suite.Run(t, new(ToolchainIntegrationValidationSuite))
 }
 
-func (s *ToolchainIntegrationValidationSuite) TestTiIDGeneration() {
-	ti := &training.ToolchainIntegration{
-		Spec: v1alpha1.ToolchainIntegrationSpec{},
-	}
-
-	_ = s.validator.ValidatesAndSetDefaults(ti)
-	s.g.Expect(ti.ID).ShouldNot(BeEmpty())
-}
-
 func (s *ToolchainIntegrationValidationSuite) TestTiEntrypointEmpty() {
 	ti := &training.ToolchainIntegration{
 		Spec: v1alpha1.ToolchainIntegrationSpec{},

--- a/packages/operator/pkg/validation/validation.go
+++ b/packages/operator/pkg/validation/validation.go
@@ -63,7 +63,7 @@ func ValidateID(id string) error {
 	}
 	err := ErrIDValidation
 	if len(id) == 0 {
-	    err = multierr.Append(err, ValidateEmpty(id))
+	    err = multierr.Append(err, ValidateEmpty("ID", id))
 	}
 	return err
 }

--- a/packages/operator/pkg/validation/validation.go
+++ b/packages/operator/pkg/validation/validation.go
@@ -29,9 +29,8 @@ import (
 )
 
 const (
-	EmptyIDErrorMessage                = "id must be nonempty"
 	SpecSectionValidationFailedMessage = "\"Spec.%q\" validation errors: %s"
-	EmptyValueStringError              = "%q parameter must be not empty"
+	EmptyValueStringError              = "\"%q\" must be not empty"
 )
 
 func ValidateEmpty(parameterName, value string) error {
@@ -62,10 +61,9 @@ func ValidateID(id string) error {
 	if idRegex.MatchString(id) {
 		return nil
 	}
-
 	err := ErrIDValidation
 	if len(id) == 0 {
-	    err = multierr.Append(err, EmptyIDErrorMessage)
+	    err = multierr.Append(err, ValidateEmpty(id))
 	}
 	return err
 }

--- a/packages/operator/pkg/validation/validation.go
+++ b/packages/operator/pkg/validation/validation.go
@@ -29,6 +29,7 @@ import (
 )
 
 const (
+	EmptyIDErrorMessage                = "id must be nonempty"
 	SpecSectionValidationFailedMessage = "\"Spec.%q\" validation errors: %s"
 	EmptyValueStringError              = "%q parameter must be not empty"
 )
@@ -62,7 +63,11 @@ func ValidateID(id string) error {
 		return nil
 	}
 
-	return ErrIDValidation
+	err := ErrIDValidation
+	if len(id) == 0 {
+	    err = multierr.Append(err, EmptyIDErrorMessage)
+	}
+	return err
 }
 
 // K8s label must start/end with alphanumeric character, can consist of


### PR DESCRIPTION
Deleted the feature for connections, model trainings, model packagings, toolchains & packagers that If `ID` parameter is not passed, ODAHU will generate one for the entity. 