### PR TITLE
Not look for Packaging integration if .Spec.IntegrationName is empty

### DIFF
--- a/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation.go
@@ -107,10 +107,13 @@ func (mpv *MpValidator) validateMainParameters(mp *packaging.ModelPackaging) (er
 
 	err = multierr.Append(err, validation.ValidateID(mp.ID))
 
+	// If image is empty then set image from Packaging Integration
 	if len(mp.Spec.Image) == 0 {
-		packagingIntegration, k8sErr := mpv.piRepo.GetPackagingIntegration(mp.Spec.IntegrationName)
-		if k8sErr != nil {
-			err = multierr.Append(err, k8sErr)
+		packagingIntegration, getPiErr := mpv.piRepo.GetPackagingIntegration(mp.Spec.IntegrationName)
+		if getPiErr != nil {
+			logMP.Info(
+				"Unable to extract default image from Packaging integration because it is empty",
+			)
 		} else {
 			mp.Spec.Image = packagingIntegration.Spec.DefaultImage
 			logMP.Info("Model packaging id is empty. Set a packaging integration image",

--- a/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation_test.go
@@ -246,19 +246,6 @@ func (s *ModelPackagingValidationSuite) TestMpImageExplicitly() {
 	s.g.Expect(mp.Spec.Image).Should(Equal(image))
 }
 
-func (s *ModelPackagingValidationSuite) TestMpImageNotFound() {
-	mp := &packaging.ModelPackaging{
-		Spec: packaging.ModelPackagingSpec{
-			IntegrationName: "not found",
-		},
-	}
-
-	err := s.validator.ValidateAndSetDefaults(mp)
-	s.g.Expect(err).Should(HaveOccurred())
-	s.g.Expect(err.Error()).Should(ContainSubstring(
-		"entity \"not found\" is not found"))
-}
-
 func (s *ModelPackagingValidationSuite) TestMpArtifactName() {
 	mp := &packaging.ModelPackaging{
 		Spec: packaging.ModelPackagingSpec{
@@ -305,7 +292,7 @@ func (s *ModelPackagingValidationSuite) TestMpIntegrationNotFound() {
 	err := s.validator.ValidateAndSetDefaults(mp)
 	s.g.Expect(err).Should(HaveOccurred())
 	s.g.Expect(err.Error()).Should(ContainSubstring(
-		"entity \"some-packaging-name\" is not found"))
+		"packaging integration with name .Spec.IntegrationName = \"some-packaging-name\" is not found"))
 }
 
 func (s *ModelPackagingValidationSuite) TestMpNotValidArgumentsSchema() {

--- a/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation_test.go
@@ -289,6 +289,10 @@ func (s *ModelPackagingValidationSuite) TestMpIntegrationNameEmpty() {
 	err := s.validator.ValidateAndSetDefaults(mp)
 	s.g.Expect(err).Should(HaveOccurred())
 	s.g.Expect(err.Error()).Should(ContainSubstring(pack_route.EmptyIntegrationNameErrorMessage))
+	// "not found" substring here is expected in case when packaging integration can't be found by
+	// .Spec.IntegrationName, but because .Spec.IntegrationName is empty we shouldn't try to find
+	// it at all
+	s.g.Expect(err.Error()).Should(Not(ContainSubstring("not found")))
 }
 
 func (s *ModelPackagingValidationSuite) TestMpIntegrationNotFound() {


### PR DESCRIPTION
If ModelPackaging.Spec.IntegrationName is empty we shouldn't try to find this integration at all when we validate ModelPackaging

closes #438 