### PR TITLE
If Connection.Spec.URI is empty then skip ECR URI specific checks

### DIFF
--- a/packages/operator/pkg/apiserver/routes/v1/connection/connection_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/connection/connection_validation.go
@@ -138,14 +138,16 @@ func (cv *ConnValidator) validateBase64Fields(conn *connection.Connection) error
 
 func (cv *ConnValidator) validateEcrType(conn *connection.Connection) (err error) {
 	// Try to parse URI
-	registry, urlParsingErr := api.ExtractRegistry(conn.Spec.URI)
-	if urlParsingErr != nil {
-		err = multierr.Append(err, fmt.Errorf(ECRTypeNotValidURI, urlParsingErr.Error()))
-	}
+	if conn.Spec.URI != "" {  // If URI is empty then skip extracting Registry and further logic
+		registry, urlParsingErr := api.ExtractRegistry(conn.Spec.URI)
+		if urlParsingErr != nil {
+			err = multierr.Append(err, fmt.Errorf(ECRTypeNotValidURI, urlParsingErr.Error()))
+		}
 
-	if len(conn.Spec.Region) == 0 && registry != nil {
-		conn.Spec.Region = registry.Region
-		logC.Info("Connection region is empty. Set region from url", "id", conn.ID, "region", registry.Region)
+		if len(conn.Spec.Region) == 0 && registry != nil {
+			conn.Spec.Region = registry.Region
+			logC.Info("Connection region is empty. Set region from url", "id", conn.ID, "region", registry.Region)
+		}
 	}
 
 	if len(conn.Spec.KeySecret) == 0 || len(conn.Spec.KeyID) == 0 {

--- a/packages/operator/pkg/apiserver/routes/v1/connection/connection_validation_test.go
+++ b/packages/operator/pkg/apiserver/routes/v1/connection/connection_validation_test.go
@@ -83,6 +83,22 @@ func (s *ConnectionValidationSuite) TestEmptyURL() {
 	s.g.Expect(err.Error()).Should(ContainSubstring(conn_route.EmptyURIErrorMessage))
 }
 
+
+func (s *ConnectionValidationSuite) TestEmptyURLEcr() {
+	conn := &connection.Connection{
+		Spec: v1alpha1.ConnectionSpec{
+			Type:      connection.EcrType,
+			Reference: connReference,
+			KeySecret: creds,
+		},
+	}
+	err := s.v.ValidatesAndSetDefaults(conn)
+	s.g.Expect(err).Should(HaveOccurred())
+	s.g.Expect(err.Error()).Should(ContainSubstring(conn_route.EmptyURIErrorMessage))
+	// If URI is empty then not validate ECR specific format of URI
+	s.g.Expect(err.Error()).Should(Not(ContainSubstring(conn_route.ECRTypeNotValidURI)))
+}
+
 func (s *ConnectionValidationSuite) TestUnknownTypeType() {
 	connType := v1alpha1.ConnectionType("not-existed")
 	conn := &connection.Connection{


### PR DESCRIPTION
closes #440 