### PR TITLE
Fix not stable golang tests

### DIFF
--- a/packages/operator/controllers/modeldeployment_controller_test.go
+++ b/packages/operator/controllers/modeldeployment_controller_test.go
@@ -95,7 +95,7 @@ func (s *ModelDeploymentControllerSuite) SetupTest() {
 	s.k8sClient = mgr.GetClient()
 	s.k8sManager = mgr
 
-	s.requests = make(chan reconcile.Request)
+	s.requests = make(chan reconcile.Request, 1000)
 
 	s.stopMgr = make(chan struct{})
 	s.mgrStopped = &sync.WaitGroup{}

--- a/packages/operator/controllers/modelpackaging_controller_test.go
+++ b/packages/operator/controllers/modelpackaging_controller_test.go
@@ -125,7 +125,7 @@ func (s *ModelPackagingControllerSuite) SetupTest() {
 	s.k8sManager = mgr
 	s.stubPIClient = stubclients.NewPIStubClient()
 
-	s.requests = make(chan reconcile.Request)
+	s.requests = make(chan reconcile.Request, 1000)
 
 	s.stopMgr = make(chan struct{})
 	s.mgrStopped = &sync.WaitGroup{}
@@ -294,7 +294,6 @@ func (s *ModelPackagingControllerSuite) TestPackagingStepConfiguration() {
 	defer s.k8sClient.Delete(context.TODO(), mp)
 
 	s.g.Eventually(s.requests, timeout).Should(Receive(Equal(mpExpectedRequest)))
-	s.g.Eventually(s.requests, timeout).Should(Receive(Equal(mpExpectedRequest)))
 
 	mpNamespacedName := types.NamespacedName{Name: mp.Name, Namespace: mp.Namespace}
 	s.g.Expect(s.k8sClient.Get(context.TODO(), mpNamespacedName, mp)).ToNot(HaveOccurred())
@@ -350,7 +349,6 @@ func (s *ModelPackagingControllerSuite) TestPackagingTimeout() {
 	s.g.Expect(err).NotTo(HaveOccurred())
 	defer s.k8sClient.Delete(context.TODO(), mp)
 
-	s.g.Eventually(s.requests, timeout).Should(Receive(Equal(mpExpectedRequest)))
 	s.g.Eventually(s.requests, timeout).Should(Receive(Equal(mpExpectedRequest)))
 
 	mpNamespacedName := types.NamespacedName{Name: mp.Name, Namespace: mp.Namespace}

--- a/packages/operator/controllers/modeltraining_controller_test.go
+++ b/packages/operator/controllers/modeltraining_controller_test.go
@@ -54,8 +54,6 @@ var (
 	gpuNodeSelector = map[string]string{"gpu-key": "gpu-value"}
 	nodeSelector    = map[string]string{"node-key": "node-value"}
 
-	mtNamespacedName         = types.NamespacedName{Name: mtName, Namespace: testNamespace}
-	expectedTrainingRequest  = reconcile.Request{NamespacedName: mtNamespacedName}
 	testResValue             = "5"
 	testToolchainIntegration = &training_apis.ToolchainIntegration{
 		ID: testToolchainIntegrationID,
@@ -349,24 +347,24 @@ func (s *ModelTrainingControllerSuite) TestTrainingStepConfiguration() {
 	k8sTrainerResources, err := kubernetes.ConvertOdahuflowResourcesToK8s(trainResources, config.NvidiaResourceName)
 	s.g.Expect(err).Should(BeNil())
 
-	mt := &odahuflowv1alpha1.ModelTraining{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      mtName,
-			Namespace: testNamespace,
-		},
-		Spec: odahuflowv1alpha1.ModelTrainingSpec{
-			Image:     toolchainImage,
-			Resources: trainResources,
-			Toolchain: testToolchainIntegrationID,
-		},
+
+	mt := newValidTraining()
+	mt.Spec = odahuflowv1alpha1.ModelTrainingSpec{
+		Image:     toolchainImage,
+		Resources: trainResources,
+		Toolchain: testToolchainIntegrationID,
 	}
 
 	err = s.k8sClient.Create(context.TODO(), mt)
 	s.g.Expect(err).NotTo(HaveOccurred())
 	defer s.k8sClient.Delete(context.TODO(), mt)
 
+	expectedTrainingRequest  := reconcile.Request{NamespacedName:
+		types.NamespacedName{Name: mt.Name, Namespace: mt.Namespace},
+	}
 	s.g.Eventually(s.requests, timeout).Should(Receive(Equal(expectedTrainingRequest)))
 
+	mtNamespacedName := types.NamespacedName{Name: mt.Name, Namespace: mt.Namespace}
 	s.g.Expect(s.k8sClient.Get(context.TODO(), mtNamespacedName, mt)).ToNot(HaveOccurred())
 
 	tr := &tektonv1beta1.TaskRun{}
@@ -423,6 +421,8 @@ func (s *ModelTrainingControllerSuite) TestTrainingTimeout() {
 	s.g.Expect(err).NotTo(HaveOccurred())
 	defer s.k8sClient.Delete(context.TODO(), mt)
 
+	mtNamespacedName := types.NamespacedName{Name: mt.Name, Namespace: mt.Namespace}
+	expectedTrainingRequest  := reconcile.Request{NamespacedName: mtNamespacedName}
 	s.g.Eventually(s.requests, timeout).Should(Receive(Equal(expectedTrainingRequest)))
 
 	s.g.Expect(s.k8sClient.Get(context.TODO(), mtNamespacedName, mt)).ToNot(HaveOccurred())
@@ -477,6 +477,8 @@ func (s *ModelTrainingControllerSuite) TestTrainingEnvs() {
 	s.g.Expect(err).NotTo(HaveOccurred())
 	defer s.k8sClient.Delete(context.TODO(), mt)
 
+	mtNamespacedName := types.NamespacedName{Name: mt.Name, Namespace: mt.Namespace}
+	expectedTrainingRequest  := reconcile.Request{NamespacedName: mtNamespacedName}
 	s.g.Eventually(s.requests, timeout).Should(Receive(Equal(expectedTrainingRequest)))
 
 	s.g.Expect(s.k8sClient.Get(context.TODO(), mtNamespacedName, mt)).ToNot(HaveOccurred())

--- a/packages/operator/controllers/modeltraining_controller_test.go
+++ b/packages/operator/controllers/modeltraining_controller_test.go
@@ -97,7 +97,7 @@ func (s *ModelTrainingControllerSuite) SetupTest() {
 	s.k8sManager = mgr
 	s.stubTIClient = stubclients.NewTIStubClient()
 
-	s.requests = make(chan reconcile.Request)
+	s.requests = make(chan reconcile.Request, 1000)
 
 	s.stopMgr = make(chan struct{})
 	s.mgrStopped = &sync.WaitGroup{}
@@ -366,7 +366,6 @@ func (s *ModelTrainingControllerSuite) TestTrainingStepConfiguration() {
 	defer s.k8sClient.Delete(context.TODO(), mt)
 
 	s.g.Eventually(s.requests, timeout).Should(Receive(Equal(expectedTrainingRequest)))
-	s.g.Eventually(s.requests, timeout).Should(Receive(Equal(expectedTrainingRequest)))
 
 	s.g.Expect(s.k8sClient.Get(context.TODO(), mtNamespacedName, mt)).ToNot(HaveOccurred())
 
@@ -425,7 +424,6 @@ func (s *ModelTrainingControllerSuite) TestTrainingTimeout() {
 	defer s.k8sClient.Delete(context.TODO(), mt)
 
 	s.g.Eventually(s.requests, timeout).Should(Receive(Equal(expectedTrainingRequest)))
-	s.g.Eventually(s.requests, timeout).Should(Receive(Equal(expectedTrainingRequest)))
 
 	s.g.Expect(s.k8sClient.Get(context.TODO(), mtNamespacedName, mt)).ToNot(HaveOccurred())
 
@@ -479,7 +477,6 @@ func (s *ModelTrainingControllerSuite) TestTrainingEnvs() {
 	s.g.Expect(err).NotTo(HaveOccurred())
 	defer s.k8sClient.Delete(context.TODO(), mt)
 
-	s.g.Eventually(s.requests, timeout).Should(Receive(Equal(expectedTrainingRequest)))
 	s.g.Eventually(s.requests, timeout).Should(Receive(Equal(expectedTrainingRequest)))
 
 	s.g.Expect(s.k8sClient.Get(context.TODO(), mtNamespacedName, mt)).ToNot(HaveOccurred())


### PR DESCRIPTION
We should not block Reconciler if &ReconcilerWrapper.requests channel was not read

* &ReconcilerWrapper.requests is now buffered not-blocking channel
* Workaround duplicates of s.g.Eventually(s.requests, timeout).Should .... are no longer needed because there are no blocked queue of .requests