### PR TITLE
Fix ODAHU ML Server discovery for service catalog

### DIFF
--- a/packages/operator/controllers/modelpackaging_controller_test.go
+++ b/packages/operator/controllers/modelpackaging_controller_test.go
@@ -295,7 +295,7 @@ func (s *ModelPackagingControllerSuite) TestPackagingStepConfiguration() {
 
 	tr := &tektonv1beta1.TaskRun{}
 	trKey := types.NamespacedName{Name: mp.Name, Namespace: testNamespace}
-	s.g.Expect(s.k8sClient.Get(context.TODO(), trKey, tr)).ToNot(HaveOccurred())
+	s.g.Eventually(func() error { return s.k8sClient.Get(context.TODO(), trKey, tr) }).ShouldNot(HaveOccurred())
 
 	expectedHelperContainerResources := v1.ResourceRequirements{
 		Limits: v1.ResourceList{
@@ -371,9 +371,7 @@ func (s *ModelPackagingControllerSuite) createPackaging(mp *odahuflowv1alpha1.Mo
 	return func() { s.k8sClient.Delete(context.TODO(), mp) }
 }
 
-func (s *ModelPackagingControllerSuite) getTektonPackagingTask(mp *odahuflowv1alpha1.ModelPackaging) (
-	*tektonv1beta1.TaskRun,
-) {
+func (s *ModelPackagingControllerSuite) getTektonPackagingTask(mp *odahuflowv1alpha1.ModelPackaging) *tektonv1beta1.TaskRun {
 	tr := &tektonv1beta1.TaskRun{}
 	trKey := types.NamespacedName{Name: mp.Name, Namespace: mp.Namespace}
 	s.Assertions.Eventually(

--- a/packages/operator/pkg/servicecatalog/discoverer.go
+++ b/packages/operator/pkg/servicecatalog/discoverer.go
@@ -39,7 +39,7 @@ func (o OdahuMLServerDiscoverer) GetMLServerName() model_types.MLServerName {
 	return model_types.MLServerODAHU
 }
 
-// ODAHU ML Server has not hardcoded swagger spec. But claims that "GET /" request
+// ODAHU ML Server doesn't have hardcoded swagger spec. But claims that "GET /api/model/info" request
 // return Swagger 2.0 spec for current deployed Model
 func (o OdahuMLServerDiscoverer) discoverSwagger(
 	prefix string, log *zap.SugaredLogger) (swagger model_types.Swagger2, err error) {

--- a/packages/operator/pkg/servicecatalog/discoverer.go
+++ b/packages/operator/pkg/servicecatalog/discoverer.go
@@ -106,7 +106,7 @@ func (o OdahuMLServerDiscoverer) generateModelRequest(prefix string) *http.Reque
 	MlServerURL := url.URL{
 		Scheme: o.EdgeURL.Scheme,
 		Host:   o.EdgeURL.Host,
-		Path:   path.Join(o.EdgeURL.Path, prefix),
+		Path:   path.Join(o.EdgeURL.Path, prefix, "api/model/info"),
 	}
 
 	return &http.Request{


### PR DESCRIPTION
PR https://github.com/odahu/odahu-flow/pull/477 changed the routing behavior to be more universal. It is not coupled with ODAHU ML Server endpoints which Service Catalog relied on. 

Previously a request to the root path `/` of the model [was rewritten](https://github.com/odahu/odahu-flow/pull/477/files#diff-d3e1742cd1f6105b93e4ac209c53a1841e4f97eff48c2ab841fedd842661a2efL205) into `/api/model/info`. It is specific endpoint of ODAHU ML Server, so it was removed when Triton predictor was introduced. 