### PR TITLE
Fix/tests operator stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           name: Lint
           command: |
             cd packages/operator
-            sleep 3600
+            make lint
       - run:
           name: Test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,22 +66,32 @@ jobs:
             go get github.com/t-yuki/gocover-cobertura
       - restore_cache:
           keys:
+            - v1-lint-cache-{{ .Branch }}
             - v1-lint-cache
+      - restore_cache:
+          keys:
+            - v1-go-mod-{{ checksum "packages/operator/go.sum" }}
+            - v1-go-mod
       - run:
           name: Lint
           command: |
             cd packages/operator
             make lint
-      - save_cache:
-          key: v1-lint-cache
-          paths:
-            - /home/circleci/.cache/golangci-lint
       - run:
           name: Test
           command: |
             cd packages/operator
             make test
             bash <(curl -s https://codecov.io/bash) -cF go # (for codecov)
+      - save_cache:
+          key: v1-lint-cache-{{ .Branch }}
+          paths:
+            - /home/circleci/.cache/golangci-lint
+      - save_cache:
+          key: v1-go-mod-{{ checksum "packages/operator/go.sum" }}
+          paths:
+            - /home/circleci/.go_workspace/pkg/mod
+            - /home/circleci/.cache/go-build
   feedback_aggregator:
     docker:
       - image: circleci/golang:1.14

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,11 +64,18 @@ jobs:
             sudo tar -zxvf /tmp/gotestsum.tar.gz -C /usr/local/
             sudo mv /usr/local/gotestsum* /usr/bin/gotestsum
             go get github.com/t-yuki/gocover-cobertura
+      - restore_cache:
+          keys:
+            - v1-lint-cache
       - run:
           name: Lint
           command: |
             cd packages/operator
             make lint
+      - save_cache:
+          key: v1-lint-cache
+          paths:
+            - /home/circleci/.cache/golangci-lint
       - run:
           name: Test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           name: Lint
           command: |
             cd packages/operator
-            make lint
+            sleep 3600
       - run:
           name: Test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,11 @@ jobs:
             sudo mv /usr/local/gotestsum* /usr/bin/gotestsum
             go get github.com/t-yuki/gocover-cobertura
       - run:
+          name: Lint
+          command: |
+            cd packages/operator
+            make lint
+      - run:
           name: Test
           command: |
             cd packages/operator

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -4,7 +4,7 @@ IMG ?= controller:latest
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 ODAHUFLOW_OPERATOR_GENERATED_ENTITIES = ../../helms/odahu-flow-core/templates/operator/generated
-LINTER_ADDITIONAL_ARGS="--verbose"
+LINTER_ADDITIONAL_ARGS="--verbose --timeout 10m0s"
 KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=600s
 
 ODAHUFLOW_NAMESPACE=odahu-flow
@@ -147,7 +147,7 @@ recreate-crds: delete-crds apply-crds
 
 ## lint: Start golangci-lint linter
 lint:
-	golangci-lint run ${LINTER_ADDITIONAL_ARGS}
+	GOGC=20 golangci-lint run ${LINTER_ADDITIONAL_ARGS}
 
 ## static-content: Generate static content for API server. Read more about installation and usage: https://github.com/rakyll/statik
 static-content:

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -4,7 +4,7 @@ IMG ?= controller:latest
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 ODAHUFLOW_OPERATOR_GENERATED_ENTITIES = ../../helms/odahu-flow-core/templates/operator/generated
-LINTER_ADDITIONAL_ARGS=--verbose -j 10 --timeout=10m0s
+LINTER_ADDITIONAL_ARGS=--verbose -j 10 --timeout=30m0s
 KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=600s
 
 ODAHUFLOW_NAMESPACE=odahu-flow

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -4,7 +4,7 @@ IMG ?= controller:latest
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 ODAHUFLOW_OPERATOR_GENERATED_ENTITIES = ../../helms/odahu-flow-core/templates/operator/generated
-LINTER_ADDITIONAL_ARGS=--verbose -j 10 --timeout=30m0s
+LINTER_ADDITIONAL_ARGS=--verbose -j 10 --timeout=20m0s
 KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=600s
 
 ODAHUFLOW_NAMESPACE=odahu-flow

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -4,7 +4,7 @@ IMG ?= controller:latest
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 ODAHUFLOW_OPERATOR_GENERATED_ENTITIES = ../../helms/odahu-flow-core/templates/operator/generated
-LINTER_ADDITIONAL_ARGS="--verbose --timeout 10m0s"
+LINTER_ADDITIONAL_ARGS="--verbose"
 KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=600s
 
 ODAHUFLOW_NAMESPACE=odahu-flow
@@ -147,7 +147,7 @@ recreate-crds: delete-crds apply-crds
 
 ## lint: Start golangci-lint linter
 lint:
-	GOGC=20 golangci-lint run ${LINTER_ADDITIONAL_ARGS}
+	GOGC=20 golangci-lint run --timeout 10m0s ${LINTER_ADDITIONAL_ARGS}
 
 ## static-content: Generate static content for API server. Read more about installation and usage: https://github.com/rakyll/statik
 static-content:

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -147,7 +147,7 @@ recreate-crds: delete-crds apply-crds
 
 ## lint: Start golangci-lint linter
 lint:
-	GOGC=20 golangci-lint run --timeout 10m0s ${LINTER_ADDITIONAL_ARGS}
+	golangci-lint run --timeout 10m0s ${LINTER_ADDITIONAL_ARGS}
 
 ## static-content: Generate static content for API server. Read more about installation and usage: https://github.com/rakyll/statik
 static-content:

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -4,7 +4,7 @@ IMG ?= controller:latest
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 ODAHUFLOW_OPERATOR_GENERATED_ENTITIES = ../../helms/odahu-flow-core/templates/operator/generated
-LINTER_ADDITIONAL_ARGS="--verbose"
+LINTER_ADDITIONAL_ARGS=--verbose -j 10 --timeout=10m0s
 KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=600s
 
 ODAHUFLOW_NAMESPACE=odahu-flow

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -147,7 +147,7 @@ recreate-crds: delete-crds apply-crds
 
 ## lint: Start golangci-lint linter
 lint:
-	golangci-lint run --timeout 10m0s ${LINTER_ADDITIONAL_ARGS}
+	golangci-lint run  ${LINTER_ADDITIONAL_ARGS}
 
 ## static-content: Generate static content for API server. Read more about installation and usage: https://github.com/rakyll/statik
 static-content:

--- a/packages/operator/controllers/modeldeployment_controller.go
+++ b/packages/operator/controllers/modeldeployment_controller.go
@@ -56,12 +56,6 @@ import (
 const (
 	deploymentControllerName             = "modeldeployment_controller"
 	DefaultModelPort                     = int32(5000)
-	defaultLivenessFailureThreshold      = 15
-	defaultLivenessPeriod                = 1
-	defaultLivenessTimeout               = 1
-	defaultReadinessFailureThreshold     = 15
-	defaultReadinessPeriod               = 1
-	defaultReadinessTimeout              = 1
 	DefaultRequeueDelay                  = 10 * time.Second
 	DefaultPortName                      = "http1"
 	KnativeMinReplicasKey                = "autoscaling.knative.dev/minScale"

--- a/packages/operator/controllers/modelpackaging_controller_test.go
+++ b/packages/operator/controllers/modelpackaging_controller_test.go
@@ -371,7 +371,8 @@ func (s *ModelPackagingControllerSuite) createPackaging(mp *odahuflowv1alpha1.Mo
 	return func() { s.k8sClient.Delete(context.TODO(), mp) }
 }
 
-func (s *ModelPackagingControllerSuite) getTektonPackagingTask(mp *odahuflowv1alpha1.ModelPackaging) *tektonv1beta1.TaskRun {
+func (s *ModelPackagingControllerSuite) getTektonPackagingTask(
+	mp *odahuflowv1alpha1.ModelPackaging) *tektonv1beta1.TaskRun {
 	tr := &tektonv1beta1.TaskRun{}
 	trKey := types.NamespacedName{Name: mp.Name, Namespace: mp.Namespace}
 	s.Assertions.Eventually(

--- a/packages/operator/controllers/modelpackaging_controller_test.go
+++ b/packages/operator/controllers/modelpackaging_controller_test.go
@@ -347,8 +347,8 @@ func (s *ModelPackagingControllerSuite) TestPackagingTimeout() {
 	mpNamespacedName := types.NamespacedName{Name: mp.Name, Namespace: mp.Namespace}
 	s.g.Expect(s.k8sClient.Get(context.TODO(), mpNamespacedName, mp)).ToNot(HaveOccurred())
 
-	tr := &tektonv1beta1.TaskRun{}
 	trKey := types.NamespacedName{Name: mp.Name, Namespace: testNamespace}
+	tr := s.getTektonPackagingTask(mp)
 	s.g.Expect(s.k8sClient.Get(context.TODO(), trKey, tr)).ToNot(HaveOccurred())
 
 	s.g.Expect(tr.Spec.Timeout.Duration).Should(Equal(time.Hour * 3))

--- a/packages/operator/controllers/modelpackaging_controller_test.go
+++ b/packages/operator/controllers/modelpackaging_controller_test.go
@@ -347,9 +347,7 @@ func (s *ModelPackagingControllerSuite) TestPackagingTimeout() {
 	mpNamespacedName := types.NamespacedName{Name: mp.Name, Namespace: mp.Namespace}
 	s.g.Expect(s.k8sClient.Get(context.TODO(), mpNamespacedName, mp)).ToNot(HaveOccurred())
 
-	trKey := types.NamespacedName{Name: mp.Name, Namespace: testNamespace}
 	tr := s.getTektonPackagingTask(mp)
-	s.g.Expect(s.k8sClient.Get(context.TODO(), trKey, tr)).ToNot(HaveOccurred())
 
 	s.g.Expect(tr.Spec.Timeout.Duration).Should(Equal(time.Hour * 3))
 }

--- a/packages/operator/controllers/modeltraining_controller_test.go
+++ b/packages/operator/controllers/modeltraining_controller_test.go
@@ -367,9 +367,7 @@ func (s *ModelTrainingControllerSuite) TestTrainingStepConfiguration() {
 	mtNamespacedName := types.NamespacedName{Name: mt.Name, Namespace: mt.Namespace}
 	s.g.Expect(s.k8sClient.Get(context.TODO(), mtNamespacedName, mt)).ToNot(HaveOccurred())
 
-	tr := &tektonv1beta1.TaskRun{}
-	trKey := types.NamespacedName{Name: mt.Name, Namespace: testNamespace}
-	s.g.Expect(s.k8sClient.Get(context.TODO(), trKey, tr)).ToNot(HaveOccurred())
+	tr := s.getTektonTrainingTask(mt)
 
 	expectedHelperContainerResources := v1.ResourceRequirements{
 		Limits: v1.ResourceList{
@@ -427,9 +425,7 @@ func (s *ModelTrainingControllerSuite) TestTrainingTimeout() {
 
 	s.g.Expect(s.k8sClient.Get(context.TODO(), mtNamespacedName, mt)).ToNot(HaveOccurred())
 
-	tr := &tektonv1beta1.TaskRun{}
-	trKey := types.NamespacedName{Name: mt.Name, Namespace: testNamespace}
-	s.g.Expect(s.k8sClient.Get(context.TODO(), trKey, tr)).ToNot(HaveOccurred())
+	tr := s.getTektonTrainingTask(mt)
 
 	s.g.Expect(tr.Spec.Timeout.Duration).Should(Equal(time.Hour * 3))
 }
@@ -483,9 +479,7 @@ func (s *ModelTrainingControllerSuite) TestTrainingEnvs() {
 
 	s.g.Expect(s.k8sClient.Get(context.TODO(), mtNamespacedName, mt)).ToNot(HaveOccurred())
 
-	tr := &tektonv1beta1.TaskRun{}
-	trKey := types.NamespacedName{Name: mt.Name, Namespace: testNamespace}
-	s.g.Expect(s.k8sClient.Get(context.TODO(), trKey, tr)).ToNot(HaveOccurred())
+	tr := s.getTektonTrainingTask(mt)
 
 	// second container is the training container
 	envs := tr.Spec.TaskSpec.Steps[1].Env

--- a/packages/operator/pkg/apiserver/routes/v1/connection/connection_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/connection/connection_validation.go
@@ -48,7 +48,6 @@ const (
 	S3TypeRegionErrorMessage         = "s3 type requires that region must be non-empty"
 	S3TypeKeySecretEmptyErrorMessage = "s3 type requires that keyID and keySecret parameters" +
 		" must be non-empty"
-	defaultIDTemplate                  = "%s-%s"
 	S3TypeRoleNotSupportedErrorMessage = "s3 type does not support role parameter yet"
 	ECRTypeKeySecretEmptyErrorMessage  = "ecr type requires that keyID and keySecret parameters" +
 		" must be non-empty"

--- a/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/packaging/model_packaging_validation.go
@@ -41,7 +41,6 @@ const (
 	EmptyIntegrationNameErrorMessage     = "empty integrationName"
 	TargetNotFoundErrorMessage           = "cannot find %s target in packaging integration %s"
 	NotValidConnTypeErrorMessage         = "%s target has not valid connection type %s for packaging integration %s"
-	defaultIDTemplate                    = "%s-%s-%s"
 	UnknownNodeSelector                  = "node selector %v is not presented in ODAHU config"
 )
 

--- a/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation.go
+++ b/packages/operator/pkg/apiserver/routes/v1/training/model_training_validation.go
@@ -44,7 +44,6 @@ const (
 		" of connections for data bindings: %v"
 	ToolchainEmptyErrorMessage = "toolchain parameter is empty"
 	UnknownNodeSelector        = "node selector %v is not presented in ODAHU config"
-	defaultIDTemplate          = "%s-%s-%s"
 )
 
 var (


### PR DESCRIPTION
* Get TaskRun in tests with a possible delay in mind (TaskRun should appear eventually not immediately) – It stabilizes tests
* Fix linter errors
* Add linter step to CI
* Increase linter timeout because in the case without cache it can run very slow
* Add caching mechanism for go linter CI jobs
* Speedup operator CI job