### PR TITLE
Odahu Predictor Rename

### DIFF
--- a/packages/commons/predictors/predictors.go
+++ b/packages/commons/predictors/predictors.go
@@ -35,7 +35,7 @@ type Predictor struct {
 
 var (
 	OdahuMLServer = Predictor{
-		ID:                "odahu-ml-server",
+		ID:                "odahu",
 		OpaPolicyFilename: "odahu_ml_server.rego",
 		Ports: []corev1.ContainerPort{{
 			Name:          "http1",


### PR DESCRIPTION
Rename "odahu-ml-server" predictor to just "odahu".
As requested in odahu/odahu-docs#107

