### PR TITLE
[#551] Insert 'kind' field on root types serialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,9 @@ generate-python-client:
 	rm -rf ${PYTHON_MODEL_DIR}
 	mkdir -p ${PYTHON_MODEL_DIR}
 	cp -r ${MOCKS_DIR}/python/odahuflow/sdk/models/* ${PYTHON_MODEL_DIR}
+
+	git apply scripts/python_models_customization.patch
+
 	git add ${PYTHON_MODEL_DIR}
 
 ## install-python-tests: Install python test dependencies

--- a/packages/sdk/odahuflow/sdk/clients/api_aggregated.py
+++ b/packages/sdk/odahuflow/sdk/clients/api_aggregated.py
@@ -37,19 +37,7 @@ from odahuflow.sdk.clients.batch_service import InferenceService, BatchInference
     AsyncBatchInferenceServiceClient
 from odahuflow.sdk.clients.batch_job import InferenceJob, BatchInferenceJobClient, AsyncBatchInferenceJobClient
 from odahuflow.sdk.models import Connection, ToolchainIntegration, ModelPackaging, PackagingIntegration
-
-TARGET_CLASSES = {
-    'ModelTraining': ModelTraining,
-    'ToolchainIntegration': ToolchainIntegration,
-    'ModelDeployment': ModelDeployment,
-    'ModelRoute': ModelRoute,
-    'Connection': Connection,
-    'ModelPackaging': ModelPackaging,
-    'PackagingIntegration': PackagingIntegration,
-    'BatchInference': PackagingIntegration,
-    'InferenceService': InferenceService,
-    'InferenceJob': InferenceJob,
-}
+from odahuflow.sdk.root_models import ROOT_MODELS
 
 LOGGER = logging.getLogger(__name__)
 
@@ -168,10 +156,10 @@ def build_resource(declaration: dict) -> OdahuflowCloudResourceUpdatePair:
     if not isinstance(resource_type, str):
         raise Exception(f'Kind of object {declaration} should be string')
 
-    if resource_type not in TARGET_CLASSES:
+    if resource_type not in ROOT_MODELS:
         raise Exception(f'Unknown kind of object: \'{resource_type}\'')
 
-    resource = TARGET_CLASSES[resource_type].from_dict(declaration)
+    resource = ROOT_MODELS[resource_type].from_dict(declaration)
 
     return OdahuflowCloudResourceUpdatePair(
         resource_id=resource.id,

--- a/packages/sdk/odahuflow/sdk/models/base_model_.py
+++ b/packages/sdk/odahuflow/sdk/models/base_model_.py
@@ -29,6 +29,12 @@ class Model(object):
         """
         result = {}
 
+        # DO NOT REMOVE: adding kind field to root API objects for polymorphism
+        from odahuflow.sdk.root_models import ROOT_MODELS
+        model_name = type(self).__name__
+        if model_name in ROOT_MODELS:
+            result['kind'] = model_name
+
         for attr, _ in six.iteritems(self.swagger_types):
             value = getattr(self, attr)
             # DO NOT REMOVE!

--- a/packages/sdk/odahuflow/sdk/root_models.py
+++ b/packages/sdk/odahuflow/sdk/root_models.py
@@ -1,0 +1,27 @@
+#  Copyright 2021 EPAM Systems
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from odahuflow.sdk.models import ModelTraining, ToolchainIntegration, ModelDeployment, ModelRoute, Connection, \
+    ModelPackaging, PackagingIntegration, InferenceService, InferenceJob
+
+ROOT_MODELS = {
+    ModelTraining.__name__: ModelTraining,
+    ToolchainIntegration.__name__: ToolchainIntegration,
+    ModelDeployment.__name__: ModelDeployment,
+    ModelRoute.__name__: ModelRoute,
+    Connection.__name__: Connection,
+    ModelPackaging.__name__: ModelPackaging,
+    PackagingIntegration.__name__: PackagingIntegration,
+    InferenceService.__name__: InferenceService,
+    InferenceJob.__name__: InferenceJob,
+}

--- a/scripts/python_models_customization.patch
+++ b/scripts/python_models_customization.patch
@@ -1,0 +1,48 @@
+Index: packages/sdk/odahuflow/sdk/models/base_model_.py
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/packages/sdk/odahuflow/sdk/models/base_model_.py b/packages/sdk/odahuflow/sdk/models/base_model_.py
+--- a/packages/sdk/odahuflow/sdk/models/base_model_.py	(revision 4188bcf9eb506e4f725978b1de3a8d10f1a32cc9)
++++ b/packages/sdk/odahuflow/sdk/models/base_model_.py	(date 1617725196036)
+@@ -29,8 +29,16 @@
+         """
+         result = {}
+ 
++        # DO NOT REMOVE: adding kind field to root API objects for polymorphism
++        from odahuflow.sdk.root_models import ROOT_MODELS
++        model_name = type(self).__name__
++        if model_name in ROOT_MODELS:
++            result['kind'] = model_name
++
+         for attr, _ in six.iteritems(self.swagger_types):
+             value = getattr(self, attr)
++            # DO NOT REMOVE!
++            attr = self.attribute_map.get(attr, attr)
+             if isinstance(value, list):
+                 result[attr] = list(map(
+                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+Index: packages/sdk/odahuflow/sdk/models/util.py
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/packages/sdk/odahuflow/sdk/models/util.py b/packages/sdk/odahuflow/sdk/models/util.py
+--- a/packages/sdk/odahuflow/sdk/models/util.py	(revision 4188bcf9eb506e4f725978b1de3a8d10f1a32cc9)
++++ b/packages/sdk/odahuflow/sdk/models/util.py	(date 1617724926702)
+@@ -23,10 +23,11 @@
+         return deserialize_date(data)
+     elif klass == datetime.datetime:
+         return deserialize_datetime(data)
+-    elif type(klass) == typing.GenericMeta:
+-        if klass.__extra__ == list:
++    # DO NOT REMOVE!
++    elif hasattr(klass, '__origin__'):
++        if klass.__origin__ == list or klass.__origin__ == typing.List:
+             return _deserialize_list(data, klass.__args__[0])
+-        if klass.__extra__ == dict:
++        if klass.__origin__ == dict or klass.__origin__ == typing.Dict:
+             return _deserialize_dict(data, klass.__args__[1])
+     else:
+         return deserialize_model(data, klass)


### PR DESCRIPTION
**Issue:** when API object is serialized in Python 'kind' field is not generated. That is a problem because an object cannot be dumped as a yaml manifest. User cannot save an object to file via `odahuflowcli` and then re-apply the file, because `kind` field is missing.

**Implementation:** I implemented the patches to apply to swagger-generated python models via a patch-file that is applied in Makefile's target.

Fixes #551