### PR TITLE
Fix scaling to zero replicas

### DIFF
--- a/packages/sdk/odahuflow/sdk/io_proc_utils.py
+++ b/packages/sdk/odahuflow/sdk/io_proc_utils.py
@@ -37,18 +37,17 @@ def run(*args: str, cwd=None, stream_output: bool = True):
 
     cmd_env = os.environ.copy()
     if stream_output:
-        child = subprocess.Popen(args, env=cmd_env, cwd=cwd, universal_newlines=True,
-                                 stdin=subprocess.PIPE)
-        exit_code = child.wait()
+        with subprocess.Popen(args, env=cmd_env, cwd=cwd, universal_newlines=True,
+                              stdin=subprocess.PIPE) as child:
+            exit_code = child.wait()
         if exit_code != 0:
             raise Exception("Non-zero exitcode: %s" % exit_code)
         return exit_code
     else:
-        child = subprocess.Popen(
-            args, env=cmd_env, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE,
-            cwd=cwd, universal_newlines=True)
-        (stdout, stderr) = child.communicate()
-        exit_code = child.wait()
+        with subprocess.Popen(args, env=cmd_env, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE,
+                              cwd=cwd, universal_newlines=True) as child:
+            stdout, stderr = child.communicate()
+            exit_code = child.wait()
         if exit_code != 0:
             raise Exception("Non-zero exit code: %s\n\nSTDOUT:\n%s\n\nSTDERR:%s\n ======" %
                             (exit_code, stdout, stderr))


### PR DESCRIPTION
**Issue**: Models never scale to zero.

Explanation: Inspecting deployed inference servers is a part of reconciliation loop so operator periodically queries some metadata. That generates a minimal HTTP on models and prevents Knative from scaling them to zero. I fixed operator to query metadata only if it is missing in `ModelDeployment` status.