### PR TITLE
Fix feedback loop

### DIFF
--- a/packages/commons/feedback/feedback.go
+++ b/packages/commons/feedback/feedback.go
@@ -21,9 +21,8 @@ type ResponseBody struct {
 }
 
 type ModelFeedback struct {
-	RequestID    string                 `json:"requestID"`
-	ModelVersion string                 `json:"modelVersion"`
-	ModelName    string                 `json:"modelName"`
-	Payload      map[string]interface{} `json:"payload"`
+	RequestID    string                 `json:"requestID" msg:"request_id"`
+	ModelVersion string                 `json:"modelVersion" msg:"model_version"`
+	ModelName    string                 `json:"modelName" msg:"model_name"`
+	Payload      map[string]interface{} `json:"payload" msg:"payload"`
 }
-

--- a/packages/feedback/pkg/tapping/collector.go
+++ b/packages/feedback/pkg/tapping/collector.go
@@ -79,7 +79,6 @@ func NewRequestCollector(
 					{
 						Name:        feedback.EnvoyInternalRoutingHeader,
 						PrefixMatch: feedback.EnvoyInternalRoutingHeaderPrefix,
-						InvertMatch: true,
 					},
 				}},
 			},


### PR DESCRIPTION
This PR fixes 2 issues:
- Model feedback is stored without model name/version
- Triton model logs stored without model name/version