### PR TITLE
[#625] fix. cannot login with interactive mode

### DIFF
--- a/packages/sdk/odahuflow/sdk/utils.py
+++ b/packages/sdk/odahuflow/sdk/utils.py
@@ -36,7 +36,7 @@ def render_template(template_name, values=None):
     """
     env = Environment(
         loader=PackageLoader(__package__, package_path='templates'),
-        autoescape=select_autoescape(enabled_extensions=('tmpl'))
+        autoescape=select_autoescape(enabled_extensions=('tmpl',))
     )
 
     if not values:

--- a/packages/sdk/odahuflow/sdk/utils.py
+++ b/packages/sdk/odahuflow/sdk/utils.py
@@ -35,8 +35,8 @@ def render_template(template_name, values=None):
     :return: str rendered template
     """
     env = Environment(
-        loader=PackageLoader(__name__, 'templates'),
-        autoescape=select_autoescape(['tmpl'])
+        loader=PackageLoader(__package__, 'templates'),
+        autoescape=select_autoescape(enabled_extensions=('tmpl'))
     )
 
     if not values:

--- a/packages/sdk/odahuflow/sdk/utils.py
+++ b/packages/sdk/odahuflow/sdk/utils.py
@@ -35,7 +35,7 @@ def render_template(template_name, values=None):
     :return: str rendered template
     """
     env = Environment(
-        loader=PackageLoader(__package__, 'templates'),
+        loader=PackageLoader(__package__, package_path='templates'),
         autoescape=select_autoescape(enabled_extensions=('tmpl'))
     )
 


### PR DESCRIPTION
jinja2.PackageLoader() requires a package name, not a module name.

**before:**
![625-before](https://user-images.githubusercontent.com/49116723/137724883-c5674ed4-b702-42e0-b007-dd3d06643e1b.png)

**after:**
![image](https://user-images.githubusercontent.com/49116723/137724830-93aeb77d-d83d-48ef-a8c3-dcf8450d264d.png)

closes #625 