### PR TITLE
Updated `Codecov.io` uploader ([depr] Bash uploader -> Codecov Uploader)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ workflows:
       - python
       - operator
       - feedback_aggregator
-      - test:
+      - test_coverage:
           requires:
             - python
             - operator
@@ -16,7 +16,7 @@ workflows:
             - hub.docker.com
           requires:
             - vulnerabilities
-            - test
+            - test_coverage
 
 jobs:
   vulnerabilities:
@@ -58,6 +58,12 @@ jobs:
           command: |
             source "$HOME/miniconda/etc/profile.d/conda.sh"
             make python-unittests
+            mkdir python_test_coverage
+            rsync .coverage python_test_coverage/
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - python_test_coverage
   operator:
     machine:
       image: ubuntu-2004:202010-01
@@ -100,6 +106,11 @@ jobs:
           command: |
             cd packages/operator
             make test
+            rsync operator-coverage.txt go_operator_coverage/
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - go_operator_coverage
       - save_cache:
           key: v1-lint-cache-{{ .Branch }}
           paths:
@@ -136,10 +147,17 @@ jobs:
           command: |
             cd packages/feedback
             make test
-  test:
+            rsync feedback-coverage.txt go_feedback_coverage/
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - go_feedback_coverage
+  test_coverage:
     docker:
-      - image: cimg/base:2021.04
+      - image: cimg/base:stable-20.04
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
           name: Prepare
           command: |
@@ -154,15 +172,15 @@ jobs:
       - run:
           name: Python CLI & SDK coverage
           command: |
-             ./codecov -vF python
+             ./codecov -s /tmp/workspace/python_test_coverage -vF python
       - run:
           name: Operator Go coverage
           command: |
-             ./codecov -s /home/circleci/go/src/github.com/odahu/odahu-flow/packages/operator -vF go,operator
+             ./codecov -s /tmp/workspace/go_operator_coverage -vF go,operator
       - run:
           name: Feedback Go coverage
           command: |
-             ./codecov -s /home/circleci/go/src/github.com/odahu/odahu-flow/packages/operator -vF go,feedback
+             ./codecov -s /tmp/workspace/go_feedback_coverage -vF go,feedback
   build:
     docker:
       - image: cimg/base:2021.01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
       - persist_to_workspace:
           root: ~/workspace
           paths:
-            - go_operator_coverage
+            - operator-coverage.txt
       - save_cache:
           key: v1-lint-cache-{{ .Branch }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,24 @@
 version: 2.1
+workflows:
+  main:
+    jobs:
+      - vulnerabilities
+      - python
+      - operator
+      - feedback_aggregator
+      - build:
+          context:
+            - hub.docker.com
+          requires:
+            - vulnerabilities
+            - python
+            - operator
+            - feedback_aggregator
+            - test
+                requires:
+                - python
+                - operator
+                - feedback_aggregator
 jobs:
   vulnerabilities:
     docker:
@@ -131,20 +151,30 @@ jobs:
           command: |
             cd packages/feedback
             make lint
-      - run:
-          name: Test
-          command: |
-            cd packages/feedback
-            make test
-            # Codecov uploader setup https://docs.codecov.com/docs/codecov-uploader
-            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
-            curl -Os https://uploader.codecov.io/latest/linux/codecov
-            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-            shasum -a 256 -c codecov.SHA256SUM
-            chmod +x codecov
-            ./codecov -vF go
+  test:
+    - run:
+        name: Prepare
+        command: |
+          # Codecov uploader setup https://docs.codecov.com/docs/codecov-uploader
+          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+          gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+          shasum -a 256 -c codecov.SHA256SUM
+          chmod +x codecov
+    - run:
+        name: Python coverage
+        command: |
+           ./codecov -vF python
+    - run:
+        name: Operator Go coverage
+        command: |
+           ./codecov -s /home/circleci/go/src/github.com/odahu/odahu-flow/packages/operator -vF go,operator
+    - run:
+        name: Feedback Go coverage
+        command: |
+           ./codecov -s /home/circleci/go/src/github.com/odahu/odahu-flow/packages/operator -vF go,feedback 
   build:
     docker:
       - image: cimg/base:2021.01
@@ -162,19 +192,3 @@ jobs:
       - run: make docker-build-model-trainer
       - run: make docker-build-model-packager
       - run: make docker-build-service-catalog
-
-workflows:
-  main:
-    jobs:
-      - vulnerabilities
-      - python
-      - operator
-      - feedback_aggregator
-      - build:
-          context:
-            - hub.docker.com
-          requires:
-            - vulnerabilities
-            - python
-            - operator
-            - feedback_aggregator

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,15 @@ jobs:
           command: |
             source "$HOME/miniconda/etc/profile.d/conda.sh"
             make python-unittests
-            bash <(curl -s https://codecov.io/bash) -cF python
+            # Codecov uploader setup https://docs.codecov.com/docs/codecov-uploader
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x codecov
+            ./codecov -vF python
   operator:
     machine:
       image: ubuntu-2004:202010-01
@@ -119,7 +127,15 @@ jobs:
           command: |
             cd packages/feedback
             make test
-            bash <(curl -s https://codecov.io/bash) -cF go # (for codecov)
+            # Codecov uploader setup https://docs.codecov.com/docs/codecov-uploader
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x codecov
+            ./codecov -vF go
   build:
     docker:
       - image: cimg/base:2021.01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,7 @@ version: 2.1
 workflows:
   main:
     jobs:
-      - vulnerabilities
       - python
-      - operator
-      - feedback_aggregator
       - test_coverage:
           requires:
             - python
@@ -13,7 +10,6 @@ workflows:
           context:
             - hub.docker.com
           requires:
-            - vulnerabilities
             - test_coverage
 
 jobs:
@@ -172,15 +168,15 @@ jobs:
       - run:
           name: Python CLI & SDK coverage
           command: |
-             ./codecov -s /tmp/workspace/python_test_coverage -vF python
+             ./codecov -f /tmp/workspace/python_test_coverage/.coverage -vF python
       - run:
           name: Operator Go coverage
           command: |
-             ./codecov -s /tmp/workspace/go_operator_coverage -vF go,operator
+             ./codecov -f /tmp/workspace/go_operator_coverage -vF go,operator
       - run:
           name: Feedback Go coverage
           command: |
-             ./codecov -s /tmp/workspace/go_feedback_coverage -vF go,feedback
+             ./codecov -f /tmp/workspace/go_feedback_coverage -vF go,feedback
   build:
     docker:
       - image: cimg/base:2021.01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,11 @@ jobs:
           name: Lint
           command: |
             make python-lint
+      - run:
+          name: Test
+          command: |
+            source "$HOME/miniconda/etc/profile.d/conda.sh"
+            make python-unittests
   operator:
     machine:
       image: ubuntu-2004:202010-01
@@ -90,6 +95,11 @@ jobs:
           command: |
             cd packages/operator
             make lint
+      - run:
+          name: Test
+          command: |
+            cd packages/operator
+            make test
       - save_cache:
           key: v1-lint-cache-{{ .Branch }}
           paths:
@@ -121,6 +131,11 @@ jobs:
           command: |
             cd packages/feedback
             make lint
+      - run:
+          name: Test
+          command: |
+            cd packages/feedback
+            make test
   test:
     docker:
       - image: cimg/base:2021.04

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,12 @@ workflows:
     jobs:
       - vulnerabilities
       - python
-      # - operator
+      - operator
       - feedback_aggregator
       - test_coverage:
           requires:
             - python
-            # - operator
+            - operator
             - feedback_aggregator
       # - build:
       #     context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,19 +6,18 @@ workflows:
       - python
       - operator
       - feedback_aggregator
+      - test:
+          requires:
+            - python
+            - operator
+            - feedback_aggregator
       - build:
           context:
             - hub.docker.com
           requires:
             - vulnerabilities
-            - python
-            - operator
-            - feedback_aggregator
             - test
-                requires:
-                - python
-                - operator
-                - feedback_aggregator
+
 jobs:
   vulnerabilities:
     docker:
@@ -54,21 +53,6 @@ jobs:
           name: Lint
           command: |
             make python-lint
-      - run:
-          name: Test
-          command: |
-            source "$HOME/miniconda/etc/profile.d/conda.sh"
-            make python-unittests
-            
-            # Codecov uploader setup https://docs.codecov.com/docs/codecov-uploader
-            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
-            curl -Os https://uploader.codecov.io/latest/linux/codecov
-            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-            shasum -a 256 -c codecov.SHA256SUM
-            chmod +x codecov
-            ./codecov -vF python
   operator:
     machine:
       image: ubuntu-2004:202010-01
@@ -106,20 +90,6 @@ jobs:
           command: |
             cd packages/operator
             make lint
-      - run:
-          name: Test
-          command: |
-            cd packages/operator
-            make test         
-            # Codecov uploader setup https://docs.codecov.com/docs/codecov-uploader
-            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
-            curl -Os https://uploader.codecov.io/latest/linux/codecov
-            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-            shasum -a 256 -c codecov.SHA256SUM
-            chmod +x codecov
-            ./codecov -vF go
       - save_cache:
           key: v1-lint-cache-{{ .Branch }}
           paths:
@@ -152,29 +122,32 @@ jobs:
             cd packages/feedback
             make lint
   test:
-    - run:
-        name: Prepare
-        command: |
-          # Codecov uploader setup https://docs.codecov.com/docs/codecov-uploader
-          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-          gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-          shasum -a 256 -c codecov.SHA256SUM
-          chmod +x codecov
-    - run:
-        name: Python coverage
-        command: |
-           ./codecov -vF python
-    - run:
-        name: Operator Go coverage
-        command: |
-           ./codecov -s /home/circleci/go/src/github.com/odahu/odahu-flow/packages/operator -vF go,operator
-    - run:
-        name: Feedback Go coverage
-        command: |
-           ./codecov -s /home/circleci/go/src/github.com/odahu/odahu-flow/packages/operator -vF go,feedback 
+    docker:
+      - image: cimg/base:2021.04
+    steps:
+      - run:
+          name: Prepare
+          command: |
+            # Codecov uploader setup https://docs.codecov.com/docs/codecov-uploader
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x codecov
+      - run:
+          name: Python CLI & SDK coverage
+          command: |
+             ./codecov -vF python
+      - run:
+          name: Operator Go coverage
+          command: |
+             ./codecov -s /home/circleci/go/src/github.com/odahu/odahu-flow/packages/operator -vF go,operator
+      - run:
+          name: Feedback Go coverage
+          command: |
+             ./codecov -s /home/circleci/go/src/github.com/odahu/odahu-flow/packages/operator -vF go,feedback
   build:
     docker:
       - image: cimg/base:2021.01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,8 +106,8 @@ jobs:
           command: |
             cd packages/operator
             make test
-            mkdir -p workspace/go_operator_coverage
-            cp operator-coverage.txt workspace/go_operator_coverage
+            mkdir -p /workspace/go_operator_coverage
+            cp operator-coverage.txt /workspace/go_operator_coverage
       - persist_to_workspace:
           root: workspace
           paths:
@@ -148,8 +148,8 @@ jobs:
           command: |
             cd packages/feedback
             make test
-            mkdir -p workspace/go_feedback_coverage
-            cp feedback-coverage.txt workspace/go_feedback_coverage
+            mkdir -p /workspace/go_feedback_coverage
+            cp feedback-coverage.txt /workspace/go_feedback_coverage
       - persist_to_workspace:
           root: workspace
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,6 @@ workflows:
       - test_coverage:
           requires:
             - python
-            - operator
-            - feedback_aggregator
       - build:
           context:
             - hub.docker.com
@@ -106,8 +104,8 @@ jobs:
           command: |
             cd packages/operator
             make test
-            mkdir -p /workspace/go_operator_coverage
-            cp operator-coverage.txt /workspace/go_operator_coverage
+            mkdir -p ~/workspace/go_operator_coverage
+            cp operator-coverage.txt ~/workspace/go_operator_coverage
       - persist_to_workspace:
           root: workspace
           paths:
@@ -148,8 +146,8 @@ jobs:
           command: |
             cd packages/feedback
             make test
-            mkdir -p /workspace/go_feedback_coverage
-            cp feedback-coverage.txt /workspace/go_feedback_coverage
+            mkdir -p ~/workspace/go_feedback_coverage
+            cp feedback-coverage.txt ~/workspace/go_feedback_coverage
       - persist_to_workspace:
           root: workspace
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,8 +58,8 @@ jobs:
           command: |
             source "$HOME/miniconda/etc/profile.d/conda.sh"
             make python-unittests
-            mkdir python_test_coverage
-            cp .coverage python_test_coverage
+            mkdir -p workspace/python_test_coverage
+            cp .coverage workspace/python_test_coverage
       - persist_to_workspace:
           root: workspace
           paths:
@@ -106,8 +106,8 @@ jobs:
           command: |
             cd packages/operator
             make test
-            mkdir go_operator_coverage
-            cp operator-coverage.txt go_operator_coverage
+            mkdir -p workspace/go_operator_coverage
+            cp operator-coverage.txt workspace/go_operator_coverage
       - persist_to_workspace:
           root: workspace
           paths:
@@ -148,8 +148,8 @@ jobs:
           command: |
             cd packages/feedback
             make test
-            mkdir go_feedback_coverage
-            cp feedback-coverage.txt go_feedback_coverage
+            mkdir -p workspace/go_feedback_coverage
+            cp feedback-coverage.txt workspace/go_feedback_coverage
       - persist_to_workspace:
           root: workspace
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  codecov: codecov/codecov@3.2.0
 jobs:
   vulnerabilities:
     docker:
@@ -39,6 +41,7 @@ jobs:
           command: |
             source "$HOME/miniconda/etc/profile.d/conda.sh"
             make python-unittests
+            
             # Codecov uploader setup https://docs.codecov.com/docs/codecov-uploader
             curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
             curl -Os https://uploader.codecov.io/latest/linux/codecov
@@ -127,13 +130,8 @@ jobs:
           command: |
             cd packages/feedback
             make test
-            # Codecov uploader setup https://docs.codecov.com/docs/codecov-uploader
-            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
-            curl -Os https://uploader.codecov.io/latest/linux/codecov
-            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-            shasum -a 256 -c codecov.SHA256SUM
+            
+            # Codecov uploader
             chmod +x codecov
             ./codecov -vF go
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ workflows:
       #     requires:
       #       - vulnerabilities
       #       - test_coverage
-
 jobs:
   vulnerabilities:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
 version: 2.1
-orbs:
-  codecov: codecov/codecov@3.2.0
 jobs:
   vulnerabilities:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,12 @@ workflows:
             - python
             - operator
             - feedback_aggregator
-      # - build:
-      #     context:
-      #       - hub.docker.com
-      #     requires:
-      #       - vulnerabilities
-      #       - test_coverage
+      - build:
+          context:
+            - hub.docker.com
+          requires:
+            - vulnerabilities
+            - test_coverage
 jobs:
   vulnerabilities:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,8 +90,16 @@ jobs:
           name: Test
           command: |
             cd packages/operator
-            make test
-            bash <(curl -s https://codecov.io/bash) -cF go # (for codecov)
+            make test         
+            # Codecov uploader setup https://docs.codecov.com/docs/codecov-uploader
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x codecov
+            ./codecov -vF go
       - save_cache:
           key: v1-lint-cache-{{ .Branch }}
           paths:
@@ -128,8 +136,13 @@ jobs:
           command: |
             cd packages/feedback
             make test
-            
-            # Codecov uploader
+            # Codecov uploader setup https://docs.codecov.com/docs/codecov-uploader
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
             chmod +x codecov
             ./codecov -vF go
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,9 +105,7 @@ jobs:
           name: Test
           command: |
             cd packages/operator
-            make test
-            echo $(pwd)
-            echo $HOME
+            make test-circle-ci
             mkdir ~/workspace
             cp operator-coverage.txt ~/workspace
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           command: |
             source "$HOME/miniconda/etc/profile.d/conda.sh"
             make python-unittests
-            mkdir -p workspace
+            mkdir workspace
             cp .coverage workspace
       - persist_to_workspace:
           root: workspace
@@ -106,10 +106,12 @@ jobs:
           command: |
             cd packages/operator
             make test
-            mkdir -p ~/workspace
+            echo $(pwd)
+            echo $HOME
+            mkdir ~/workspace
             cp operator-coverage.txt ~/workspace
       - persist_to_workspace:
-          root: workspace
+          root: ~/workspace
           paths:
             - go_operator_coverage
       - save_cache:
@@ -148,12 +150,12 @@ jobs:
           command: |
             cd packages/feedback
             make test
-            mkdir -p ~/workspace
+            mkdir ~/workspace
             cp feedback-coverage.txt ~/workspace
       - persist_to_workspace:
-          root: workspace
+          root: ~/workspace
           paths:
-            - go_feedback_coverage
+            - feedback-coverage.txt
   test_coverage:
     docker:
       - image: cimg/base:stable-20.04

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
             source "$HOME/miniconda/etc/profile.d/conda.sh"
             make python-unittests
             mkdir python_test_coverage
-            rsync .coverage python_test_coverage/
+            cp .coverage python_test_coverage
       - persist_to_workspace:
           root: workspace
           paths:
@@ -106,7 +106,8 @@ jobs:
           command: |
             cd packages/operator
             make test
-            rsync operator-coverage.txt go_operator_coverage/
+            mkdir go_operator_coverage
+            cp operator-coverage.txt go_operator_coverage
       - persist_to_workspace:
           root: workspace
           paths:
@@ -147,7 +148,8 @@ jobs:
           command: |
             cd packages/feedback
             make test
-            rsync feedback-coverage.txt go_feedback_coverage/
+            mkdir go_feedback_coverage
+            cp feedback-coverage.txt go_feedback_coverage
       - persist_to_workspace:
           root: workspace
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
           name: Test
           command: |
             cd packages/operator
-            make test-circle-ci
+            make test
             mkdir ~/workspace
             cp operator-coverage.txt ~/workspace
       - persist_to_workspace:
@@ -162,8 +162,8 @@ jobs:
       - run:
           name: Prepare
           command: |
-            # Codecov uploader setup https://docs.codecov.com/docs/codecov-uploader
-            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+            # Codecov uploader https://docs.codecov.com/docs/codecov-uploader
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
             curl -Os https://uploader.codecov.io/latest/linux/codecov
             curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
             curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,9 @@ workflows:
             - hub.docker.com
           requires:
             - vulnerabilities
-            - test_coverage
+            - python
+            - operator
+            - feedback_aggregator
 jobs:
   vulnerabilities:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,15 +2,21 @@ version: 2.1
 workflows:
   main:
     jobs:
+      - vulnerabilities
       - python
+      # - operator
+      - feedback_aggregator
       - test_coverage:
           requires:
             - python
-      - build:
-          context:
-            - hub.docker.com
-          requires:
-            - test_coverage
+            # - operator
+            - feedback_aggregator
+      # - build:
+      #     context:
+      #       - hub.docker.com
+      #     requires:
+      #       - vulnerabilities
+      #       - test_coverage
 
 jobs:
   vulnerabilities:
@@ -52,12 +58,12 @@ jobs:
           command: |
             source "$HOME/miniconda/etc/profile.d/conda.sh"
             make python-unittests
-            mkdir -p workspace/python_test_coverage
-            cp .coverage workspace/python_test_coverage
+            mkdir -p workspace
+            cp .coverage workspace
       - persist_to_workspace:
           root: workspace
           paths:
-            - python_test_coverage
+            - .coverage
   operator:
     machine:
       image: ubuntu-2004:202010-01
@@ -100,8 +106,8 @@ jobs:
           command: |
             cd packages/operator
             make test
-            mkdir -p ~/workspace/go_operator_coverage
-            cp operator-coverage.txt ~/workspace/go_operator_coverage
+            mkdir -p ~/workspace
+            cp operator-coverage.txt ~/workspace
       - persist_to_workspace:
           root: workspace
           paths:
@@ -142,8 +148,8 @@ jobs:
           command: |
             cd packages/feedback
             make test
-            mkdir -p ~/workspace/go_feedback_coverage
-            cp feedback-coverage.txt ~/workspace/go_feedback_coverage
+            mkdir -p ~/workspace
+            cp feedback-coverage.txt ~/workspace
       - persist_to_workspace:
           root: workspace
           paths:
@@ -168,15 +174,15 @@ jobs:
       - run:
           name: Python CLI & SDK coverage
           command: |
-             ./codecov -f /tmp/workspace/python_test_coverage/.coverage -vF python
+             ./codecov -f /tmp/workspace/.coverage -vF python
       - run:
           name: Operator Go coverage
           command: |
-             ./codecov -f /tmp/workspace/go_operator_coverage -vF go,operator
+             ./codecov -f /tmp/workspace/operator-coverage.txt -vF go,operator
       - run:
           name: Feedback Go coverage
           command: |
-             ./codecov -f /tmp/workspace/go_feedback_coverage -vF go,feedback
+             ./codecov -f /tmp/workspace/feedback-coverage.txt -vF go,feedback
   build:
     docker:
       - image: cimg/base:2021.01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,16 @@ workflows:
   main:
     jobs:
       - vulnerabilities
-      - python
-      - operator
-      - feedback_aggregator
-      - test_coverage:
+      - test_coverage
+      - python:
           requires:
-            - python
-            - operator
-            - feedback_aggregator
+            - test_coverage
+      - operator:
+          requires:
+            - test_coverage
+      - feedback_aggregator:
+          requires:
+            - test_coverage
       - build:
           context:
             - hub.docker.com
@@ -43,26 +45,17 @@ jobs:
             make install-python-tests
             make install-python-linter
       - run:
-          name: Code coverage
-          command: |
-            source "$HOME/miniconda/etc/profile.d/conda.sh"
-            pip install codecov
-            pip install pytest-cov
-      - run:
           name: Lint
           command: |
             make python-lint
+      - attach_workspace:
+          at: /tmp/codecov-uploader
       - run:
           name: Test
           command: |
             source "$HOME/miniconda/etc/profile.d/conda.sh"
             make python-unittests
-            mkdir workspace
-            cp .coverage workspace
-      - persist_to_workspace:
-          root: workspace
-          paths:
-            - .coverage
+            /tmp/codecov-uploader/codecov -f coverage.xml -vF python
   operator:
     machine:
       image: ubuntu-2004:202010-01
@@ -100,17 +93,14 @@ jobs:
           command: |
             cd packages/operator
             make lint
+      - attach_workspace:
+          at: /tmp/codecov-uploader
       - run:
           name: Test
           command: |
             cd packages/operator
             make test
-            mkdir ~/workspace
-            cp operator-coverage.txt ~/workspace
-      - persist_to_workspace:
-          root: ~/workspace
-          paths:
-            - operator-coverage.txt
+            /tmp/codecov-uploader/codecov -vF go,operator
       - save_cache:
           key: v1-lint-cache-{{ .Branch }}
           paths:
@@ -142,23 +132,18 @@ jobs:
           command: |
             cd packages/feedback
             make lint
+      - attach_workspace:
+          at: /tmp/codecov-uploader
       - run:
           name: Test
           command: |
             cd packages/feedback
             make test
-            mkdir ~/workspace
-            cp feedback-coverage.txt ~/workspace
-      - persist_to_workspace:
-          root: ~/workspace
-          paths:
-            - feedback-coverage.txt
+            /tmp/codecov-uploader/codecov -vF go,feedback
   test_coverage:
     docker:
       - image: cimg/base:stable-20.04
     steps:
-      - attach_workspace:
-          at: /tmp/workspace
       - run:
           name: Prepare
           command: |
@@ -170,21 +155,13 @@ jobs:
             gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
             shasum -a 256 -c codecov.SHA256SUM
             chmod +x codecov
-      - run:
-          name: Python CLI & SDK coverage
-          command: |
-             ./codecov -f /tmp/workspace/.coverage -vF python
-      - run:
-          name: Operator Go coverage
-          command: |
-             ./codecov -f /tmp/workspace/operator-coverage.txt -vF go,operator
-      - run:
-          name: Feedback Go coverage
-          command: |
-             ./codecov -f /tmp/workspace/feedback-coverage.txt -vF go,feedback
+      - persist_to_workspace:
+          root: .
+          paths:
+            - codecov
   build:
     docker:
-      - image: cimg/base:2021.01
+      - image: cimg/base:stable-20.04
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,9 @@ install-python-tests:
 
 ## python-unittests: Run pythoon unit tests
 python-unittests:
-	DEBUG=true VERBOSE=true pytest -s --cov --cov-report term-missing\
+	DEBUG=true VERBOSE=true \
+	pytest -s --cov --cov-report term-missing \
+			  --cov-branch \
 	          packages/cli packages/sdk
 
 ## setup-e2e-robot: Prepare a test data for the e2e robot tests

--- a/Makefile
+++ b/Makefile
@@ -219,8 +219,9 @@ install-python-tests:
 ## python-unittests: Run pythoon unit tests
 python-unittests:
 	DEBUG=true VERBOSE=true \
-	pytest -s --cov --cov-report term-missing \
-			  --cov-branch \
+	pytest -s --cov --cov-branch \
+			  --cov-report term-missing \
+		  	  --cov-report xml:coverage.xml \
 	          packages/cli packages/sdk
 
 ## setup-e2e-robot: Prepare a test data for the e2e robot tests

--- a/packages/feedback/Makefile
+++ b/packages/feedback/Makefile
@@ -6,7 +6,9 @@ all: help
 
 ## test: Run unit tests
 test:
-	gotestsum --junitfile feedback-report.xml -- -race -coverprofile=coverage.txt ./pkg/...
+	gotestsum -race -covermode=atomic \
+			  --junitfile feedback-report.xml -- \
+			  -coverprofile=feedback-coverage.txt ./pkg/...
 
 ## build-all: Buld all services
 build-all: build-collector build-rq-catcher

--- a/packages/feedback/Makefile
+++ b/packages/feedback/Makefile
@@ -6,8 +6,8 @@ all: help
 
 ## test: Run unit tests
 test:
-	gotestsum -race -covermode=atomic \
-			  --junitfile feedback-report.xml -- \
+	gotestsum --junitfile feedback-report.xml -- \
+			  -race -covermode=atomic \
 			  -coverprofile=feedback-coverage.txt ./pkg/...
 
 ## build-all: Buld all services

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -40,7 +40,7 @@ test: generate manifests
 ## 				   don't add -race & -covermode=atomic options, test fails
 test-circle-ci: generate manifests
 	gotestsum --junitfile operator-report.xml -- \
-			  -coverprofile=operator-coverage.txt \
+			  -covermode=atomic -coverprofile=operator-coverage.txt \
 			  $(go list ./... | circleci tests split)
 
 ## build-operator: Build operator executable binary

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -31,15 +31,15 @@ endif
 all: help
 
 ## test: Run unit tests
+## 		 don't add -race & -covermode=atomic options, test fails
 test: generate manifests
 	gotestsum --junitfile operator-report.xml -- \
-			  # don't add -race & -covermode=atomic options, test fails
 			  -coverprofile=operator-coverage.txt ./...
 
 ## test-circle-ci: Run unit tests in parallel on CircleCI
+## 				   don't add -race & -covermode=atomic options, test fails
 test-circle-ci: generate manifests
 	gotestsum --junitfile operator-report.xml -- \
-			  # don't add -race & -covermode=atomic options, test fails
 			  -coverprofile=operator-coverage.txt \
 			  $(go list ./... | circleci tests split)
 

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -33,7 +33,7 @@ all: help
 ## help: Run unit tests
 test: generate manifests
 	gotestsum --junitfile operator-report.xml -- \
-			  -race -covermode=atomic \
+			  -covermode=atomic \
 			  -coverprofile=operator-coverage.txt ./...
 
 ## build-operator: Build operator executable binary

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -32,8 +32,8 @@ all: help
 
 ## help: Run unit tests
 test: generate manifests
-	gotestsum -race -covermode=atomic \
-			  --junitfile operator-report.xml -- \
+	gotestsum --junitfile operator-report.xml -- \
+			  -race -covermode=atomic \
 			  -coverprofile=operator-coverage.txt ./...
 
 ## build-operator: Build operator executable binary

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -31,17 +31,11 @@ endif
 all: help
 
 ## test: Run unit tests
-## 		 don't add -race & -covermode=atomic options, test fails
+## 		 don't add -race option, test fails
 test: generate manifests
 	gotestsum --junitfile operator-report.xml -- \
+			  -covermode=atomic \
 			  -coverprofile=operator-coverage.txt ./...
-
-## test-circle-ci: Run unit tests in parallel on CircleCI
-## 				   don't add -race & -covermode=atomic options, test fails
-test-circle-ci: generate manifests
-	go test -covermode=atomic \
-			-coverprofile=operator-coverage.txt \
-			-v $(go list ./... | circleci tests split)
 
 ## build-operator: Build operator executable binary
 build-operator: generate

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -32,7 +32,9 @@ all: help
 
 ## help: Run unit tests
 test: generate manifests
-	gotestsum --junitfile operator-report.xml -- -coverprofile=coverage.txt ./...
+	gotestsum -race -covermode=atomic \
+			  --junitfile operator-report.xml -- \
+			  -coverprofile=operator-coverage.txt ./...
 
 ## build-operator: Build operator executable binary
 build-operator: generate

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -30,11 +30,18 @@ endif
 
 all: help
 
-## help: Run unit tests
+## test: Run unit tests
 test: generate manifests
 	gotestsum --junitfile operator-report.xml -- \
-			  -covermode=atomic \
+			  # don't add -race & -covermode=atomic options, test fails
 			  -coverprofile=operator-coverage.txt ./...
+
+## test-circle-ci: Run unit tests in parallel on CircleCI
+test-circle-ci: generate manifests
+	gotestsum --junitfile operator-report.xml -- \
+			  # don't add -race & -covermode=atomic options, test fails
+			  -coverprofile=operator-coverage.txt \
+			  $(go list ./... | circleci tests split)
 
 ## build-operator: Build operator executable binary
 build-operator: generate

--- a/packages/operator/Makefile
+++ b/packages/operator/Makefile
@@ -39,9 +39,9 @@ test: generate manifests
 ## test-circle-ci: Run unit tests in parallel on CircleCI
 ## 				   don't add -race & -covermode=atomic options, test fails
 test-circle-ci: generate manifests
-	gotestsum --junitfile operator-report.xml -- \
-			  -covermode=atomic -coverprofile=operator-coverage.txt \
-			  $(go list ./... | circleci tests split)
+	go test -covermode=atomic \
+			-coverprofile=operator-coverage.txt \
+			-v $(go list ./... | circleci tests split)
 
 ## build-operator: Build operator executable binary
 build-operator: generate


### PR DESCRIPTION
The Codecov uploader which  is used now is deprecated: [Bash uploader](https://docs.codecov.com/docs/about-the-codecov-bash-uploader) (Related link: [Security incident with Bash Uploader](https://about.codecov.io/security-update/?utm_medium=article&utm_source=blog&utm_campaign=security-incident&utm_content=security-event&utm_term=clicked-inline-cta))

Therefore, I switched to the recommended one: [Codecov uploader](https://docs.codecov.com/docs/codecov-uploader).