### PR TITLE
[#628][fix] unpin numpy sdk requirement: numpy>=1.19.2

### DIFF
--- a/packages/sdk/requirements.txt
+++ b/packages/sdk/requirements.txt
@@ -8,4 +8,4 @@ dataclasses>=0.6
 typing-extensions>=3.6.5
 idna-ssl>=1.1.0
 docker>=4.2.0
-numpy==1.19.2
+numpy>=1.19.2


### PR DESCRIPTION
close #628 