### PR TITLE
make all connections created during tests setup non-vital

### DIFF
--- a/packages/tests/stuff/training_stuff.sh
+++ b/packages/tests/stuff/training_stuff.sh
@@ -171,7 +171,7 @@ function create_test_data_connection() {
 
   # Replaced the uri with the test data directory and added the kind field
   odahuflowctl conn get --id models-output --decrypted -o json |
-    conn_uri="${conn_uri}" jq '.[0].spec.uri = env.conn_uri | .[] | .kind = "Connection"' \
+    conn_uri="${conn_uri}" jq '.[0].spec.uri = env.conn_uri | .[] | .kind = "Connection" | del(.spec.vital)' \
       >"${conn_file}"
 
   odahuflowctl conn delete --id "${conn_id}" --ignore-not-found


### PR DESCRIPTION
Fixes tests during the cleanup step.